### PR TITLE
(Randomized) Deferred Model Init

### DIFF
--- a/src/piper.py
+++ b/src/piper.py
@@ -52,15 +52,15 @@ def piper(gm, example_inputs, **kwargs):
         if dp_degree > 1:
             stage_gm = _insert_a2a_ops(stage_gm)
 
-        # stage_gm(*graphargs)
-        # start = torch.cuda.Event(enable_timing=True)
-        # start.record()
-        # for i in range(5):
-        #     stage_gm(*graphargs)
-        # end = torch.cuda.Event(enable_timing=True)
-        # end.record()
-        # torch.cuda.synchronize()
-        # print(f"Stage {stage_id} time measured on controller: {start.elapsed_time(end) / 5:.2f} ms")
+        stage_gm(*graphargs)
+        start = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for i in range(5):
+            stage_gm(*graphargs)
+        end = torch.cuda.Event(enable_timing=True)
+        end.record()
+        torch.cuda.synchronize()
+        print(f"Stage {stage_id} time measured on controller: {start.elapsed_time(end) / 5:.2f} ms")
 
         actor_id = piper_metadata.stage_to_device[stage_id]
         actor = _get_actor(actor_id)
@@ -92,11 +92,11 @@ def piper(gm, example_inputs, **kwargs):
         if stage_id < len(piper_metadata.stage_to_device.keys()) - 1:
             piper_metadata.dag.add((stage_id, stage_id+1))
     
-    # example_outputs = original_gm(*example_inputs)
+    example_outputs = original_gm(*example_inputs)
 
     def callback(*args):
         logger.warning("Should not directly call compiled module, running non-distributed execution")
-        # return example_outputs
+        return example_outputs
 
     del original_gm
     del example_inputs

--- a/src/piper.py
+++ b/src/piper.py
@@ -25,8 +25,18 @@ def piper(gm, example_inputs, **kwargs):
     # end.record()
     # torch.cuda.synchronize()
     # print(f"Entire model time measured on controller: {start.elapsed_time(end) / 10:.2f} ms")
+    def _dump_get_attrs(tag, gm_):
+        attrs = [n.target for n in gm_.graph.nodes if n.op == "get_attr"]
+        print(f"[{tag}] get_attr targets:", attrs)
+
+    # print("gm code:")
+    # gm.print_readable()
+    # print("nodes:", [(n.op, n.target) for n in gm.graph.nodes])
 
     original_gm = gm
+
+    # _dump_get_attrs("original gm", original_gm)
+
     top_level_gm, submodules = _split_gm_by_stages(gm)
     num_stages = len(piper_metadata.stage_to_device.keys())
     dp_rank = int(os.environ['PIPER_DP_RANK'])
@@ -42,19 +52,22 @@ def piper(gm, example_inputs, **kwargs):
         if dp_degree > 1:
             stage_gm = _insert_a2a_ops(stage_gm)
 
-        stage_gm(*graphargs)
-        start = torch.cuda.Event(enable_timing=True)
-        start.record()
-        for i in range(5):
-            stage_gm(*graphargs)
-        end = torch.cuda.Event(enable_timing=True)
-        end.record()
-        torch.cuda.synchronize()
-        print(f"Stage {stage_id} time measured on controller: {start.elapsed_time(end) / 5:.2f} ms")
+        # stage_gm(*graphargs)
+        # start = torch.cuda.Event(enable_timing=True)
+        # start.record()
+        # for i in range(5):
+        #     stage_gm(*graphargs)
+        # end = torch.cuda.Event(enable_timing=True)
+        # end.record()
+        # torch.cuda.synchronize()
+        # print(f"Stage {stage_id} time measured on controller: {start.elapsed_time(end) / 5:.2f} ms")
 
         actor_id = piper_metadata.stage_to_device[stage_id]
         actor = _get_actor(actor_id)
         actor_stages.append((actor, stage_id))
+        
+
+        # _dump_get_attrs(f"stage{stage_id}-pre-serialize", stage_gm)
 
         stage_gm_data = _serialize_graphmodule(stage_gm)
         refs.append(actor._load_stage.remote(
@@ -79,11 +92,11 @@ def piper(gm, example_inputs, **kwargs):
         if stage_id < len(piper_metadata.stage_to_device.keys()) - 1:
             piper_metadata.dag.add((stage_id, stage_id+1))
     
-    example_outputs = original_gm(*example_inputs)
+    # example_outputs = original_gm(*example_inputs)
 
     def callback(*args):
         logger.warning("Should not directly call compiled module, running non-distributed execution")
-        return example_outputs
+        # return example_outputs
 
     del original_gm
     del example_inputs

--- a/src/piper.py
+++ b/src/piper.py
@@ -16,34 +16,14 @@ logger = create_logger("piper_backend", LOG_LEVEL)
 @register_backend
 def piper(gm, example_inputs, **kwargs):
 
-    # gm(*example_inputs)
-    # start = torch.cuda.Event(enable_timing=True)
-    # start.record()
-    # for i in range(10):
-    #     gm(*example_inputs)
-    # end = torch.cuda.Event(enable_timing=True)
-    # end.record()
-    # torch.cuda.synchronize()
-    # print(f"Entire model time measured on controller: {start.elapsed_time(end) / 10:.2f} ms")
-    def _dump_get_attrs(tag, gm_):
-        attrs = [n.target for n in gm_.graph.nodes if n.op == "get_attr"]
-        print(f"[{tag}] get_attr targets:", attrs)
-
-    # print("gm code:")
-    # gm.print_readable()
-    # print("nodes:", [(n.op, n.target) for n in gm.graph.nodes])
-
     original_gm = gm
-
-    # _dump_get_attrs("original gm", original_gm)
-
     top_level_gm, submodules = _split_gm_by_stages(gm)
+    
     num_stages = len(piper_metadata.stage_to_device.keys())
     dp_rank = int(os.environ['PIPER_DP_RANK'])
     pp_degree = int(os.environ['PIPER_PP_DEGREE'])
     dp_degree = int(os.environ['PIPER_DP_DEGREE'])
 
-    # top_level_gm.print_readable()
     del top_level_gm
 
     refs = []
@@ -66,9 +46,6 @@ def piper(gm, example_inputs, **kwargs):
         actor = _get_actor(actor_id)
         actor_stages.append((actor, stage_id))
         
-
-        # _dump_get_attrs(f"stage{stage_id}-pre-serialize", stage_gm)
-
         stage_gm_data = _serialize_graphmodule(stage_gm)
         refs.append(actor._load_stage.remote(
             stage_id, 

--- a/src/piper_actor.py
+++ b/src/piper_actor.py
@@ -123,6 +123,10 @@ class PiperActor:
         self.overlapped_comp_stream = torch.cuda.Stream()
         self.overlapped_p2p_stream = torch.cuda.Stream()
 
+        # fields for deferred initialization
+        self.forward_args_meta = dict()
+        self.stage_materialized = defaultdict(bool)
+
         # map stage id -> compiled fx.Graph function
         self.forward_fns = dict()
         # map stage id -> original GraphModule (for hook registration)
@@ -326,51 +330,123 @@ class PiperActor:
                         self.comm_op_handles[stage_id][tid].wait()
                         done = True
 
-    def _load_stage(
-        self, stage_id: int, gm_data, forward_args,input_idxs
-    ):
+    # def _load_stage(
+    #     self, stage_id: int, gm_data, forward_args,input_idxs
+    # ):
+    #     self.logger.debug(f"Loading stage {stage_id} graph on actor {self.global_rank}")
+
+    #     # compile the graph with the given graphargs
+    #     gm = _deserialize_graphmodule(gm_data)
+
+    #     # Store GraphModule reference
+    #     self.graph_modules[stage_id] = gm
+    #     self.forward_fns[stage_id] = gm.forward
+
+    #     # place parameters on the device
+    #     def move_to_device(idx, arg):
+    #         if arg.requires_grad:
+    #             return arg.to(self.device).detach().requires_grad_(True)
+    #         else:
+    #             return arg.to(self.device)
+    #     forward_args = list(map(move_to_device, range(len(forward_args)), forward_args))
+
+    #     # save parameters
+    #     self.forward_args[stage_id] = forward_args
+    #     self.stage_id = stage_id
+    #     self.input_idxs[stage_id] = input_idxs
+
+    #     for i in self.input_idxs[stage_id]:
+    #         self.forward_input_meta[stage_id][i] = (
+    #             forward_args[i].shape,
+    #             forward_args[i].dtype,
+    #             forward_args[i].requires_grad,
+    #         )
+    #         self.forward_args[stage_id][i] = None
+
+    #     # prepare tensors with DP comm ops
+    #     if not self.naive_gradient_sync and self.dp_degree > 1:
+    #         self._prepare_dp_comm_ops(stage_id)
+
+    #     # add the parameters to the optimizer for this stage
+    #     params = [param for param in forward_args if param is not None and param.requires_grad]
+    #     if stage_id not in self.optims:
+    #         self.optims[stage_id] = self.optim_class(params)
+    #     else:
+    #         self.optims[stage_id].add_param_group({"params": params})
+
+    #     del gm_data
+    def _load_stage(self, stage_id: int, gm_data, forward_args, input_idxs):
         self.logger.debug(f"Loading stage {stage_id} graph on actor {self.global_rank}")
 
-        # compile the graph with the given graphargs
         gm = _deserialize_graphmodule(gm_data)
 
-        # Store GraphModule reference
         self.graph_modules[stage_id] = gm
         self.forward_fns[stage_id] = gm.forward
 
-        # place parameters on the device
-        def move_to_device(idx, arg):
-            if arg.requires_grad:
-                return arg.to(self.device).detach().requires_grad_(True)
-            else:
-                return arg.to(self.device)
-        forward_args = list(map(move_to_device, range(len(forward_args)), forward_args))
-
-        # save parameters
-        self.forward_args[stage_id] = forward_args
-        self.stage_id = stage_id
+        forward_args = list(forward_args)
         self.input_idxs[stage_id] = input_idxs
 
+        # Save input meta and punch holes
         for i in self.input_idxs[stage_id]:
             self.forward_input_meta[stage_id][i] = (
                 forward_args[i].shape,
                 forward_args[i].dtype,
                 forward_args[i].requires_grad,
             )
-            self.forward_args[stage_id][i] = None
+            forward_args[i] = None
 
-        # prepare tensors with DP comm ops
+        self.forward_args_meta[stage_id] = forward_args
+        self.forward_args[stage_id] = list(forward_args)
+        self.stage_materialized[stage_id] = False
+
+        del gm_data
+
+    def materialize_stage(self, stage_id: int, init="random", seed=0):
+        if self.stage_materialized[stage_id]:
+            return 1
+
+        meta_args = self.forward_args_meta[stage_id]
+        realized = [None] * len(meta_args)
+
+        g = torch.Generator(device=self.device)
+        g.manual_seed(seed + 1000 * self.global_rank + stage_id)
+
+        for i, arg in enumerate(meta_args):
+            if arg is None:
+                continue
+
+            t = torch.empty(arg.shape, dtype=arg.dtype, device=self.device)
+
+            if arg.requires_grad:
+                t.requires_grad_(True)
+                if init == "random":
+                    torch.nn.init.normal_(t, mean=0.0, std=0.02, generator=g)
+            else:
+                t.zero_()
+
+            realized[i] = t
+
+        self.forward_args[stage_id] = realized
+        self.stage_materialized[stage_id] = True
+
+        # Now safe to setup hooks + optimizer
         if not self.naive_gradient_sync and self.dp_degree > 1:
             self._prepare_dp_comm_ops(stage_id)
 
-        # add the parameters to the optimizer for this stage
-        params = [param for param in forward_args if param is not None and param.requires_grad]
+        params = [t for t in realized if t is not None and t.requires_grad]
+
         if stage_id not in self.optims:
             self.optims[stage_id] = self.optim_class(params)
         else:
             self.optims[stage_id].add_param_group({"params": params})
 
-        del gm_data
+        return 1
+
+
+    def materialize_all_stages(self, init="random", seed=0):
+        for stage_id in list(self.forward_args_meta.keys()):
+            self.materialize_stage(stage_id, init=init, seed=seed)
+        return 1
 
     def _exec_p2p_op(
         self, src_stage: int, dst_stage: int, mb_idx: int, is_sender: bool, dep, p2p_stream=None
@@ -666,6 +742,10 @@ class PiperActor:
             f"Calling forward {stage_id} mb {mb_idx} on actor {self.global_rank}"
         )
 
+        assert (
+            self.stage_materialized[stage_id]
+        ), f"Stage {stage_id} not materialized on actor {self.global_rank}"
+
         if stage_id == 0:
             # For the first stage, load input tensors from self.inputs
             for i, inp in zip(self.input_idxs[stage_id], self.inputs):
@@ -744,6 +824,11 @@ class PiperActor:
         self.logger.debug(
             f"Calling backward {stage_id} mb {mb_idx} on actor {self.global_rank}"
         )
+
+        assert (
+            self.stage_materialized[stage_id]
+        ), f"Stage {stage_id} not materialized on actor {self.global_rank}"
+
         out_activation = self.out_activation[stage_id][mb_idx]
 
         if stage_id < self.num_stages - 1:

--- a/src/piper_actor.py
+++ b/src/piper_actor.py
@@ -401,7 +401,7 @@ class PiperActor:
 
         del gm_data
 
-    def materialize_stage(self, stage_id: int, init="random", seed=0):
+    def materialize_stage(self, stage_id: int):
         if self.stage_materialized[stage_id]:
             return 1
 
@@ -409,7 +409,7 @@ class PiperActor:
         realized = [None] * len(meta_args)
 
         g = torch.Generator(device=self.device)
-        g.manual_seed(seed + 1000 * self.global_rank + stage_id)
+        g.manual_seed(0 + 1000 * self.global_rank + stage_id)
 
         for i, arg in enumerate(meta_args):
             if arg is None:
@@ -419,8 +419,7 @@ class PiperActor:
 
             if arg.requires_grad:
                 t.requires_grad_(True)
-                if init == "random":
-                    torch.nn.init.normal_(t, mean=0.0, std=0.02, generator=g)
+                torch.nn.init.normal_(t, mean=0.0, std=0.02, generator=g)
             else:
                 t.zero_()
 
@@ -443,9 +442,9 @@ class PiperActor:
         return 1
 
 
-    def materialize_all_stages(self, init="random", seed=0):
+    def materialize_all_stages(self):
         for stage_id in list(self.forward_args_meta.keys()):
-            self.materialize_stage(stage_id, init=init, seed=seed)
+            self.materialize_stage(stage_id)
         return 1
 
     def _exec_p2p_op(

--- a/src/piper_actor.py
+++ b/src/piper_actor.py
@@ -123,7 +123,7 @@ class PiperActor:
         self.overlapped_comp_stream = torch.cuda.Stream()
         self.overlapped_p2p_stream = torch.cuda.Stream()
 
-        # fields for deferred initialization
+        # maps for deferred initialization
         self.forward_args_meta = dict()
         self.stage_materialized = defaultdict(bool)
 
@@ -330,51 +330,6 @@ class PiperActor:
                         self.comm_op_handles[stage_id][tid].wait()
                         done = True
 
-    # def _load_stage(
-    #     self, stage_id: int, gm_data, forward_args,input_idxs
-    # ):
-    #     self.logger.debug(f"Loading stage {stage_id} graph on actor {self.global_rank}")
-
-    #     # compile the graph with the given graphargs
-    #     gm = _deserialize_graphmodule(gm_data)
-
-    #     # Store GraphModule reference
-    #     self.graph_modules[stage_id] = gm
-    #     self.forward_fns[stage_id] = gm.forward
-
-    #     # place parameters on the device
-    #     def move_to_device(idx, arg):
-    #         if arg.requires_grad:
-    #             return arg.to(self.device).detach().requires_grad_(True)
-    #         else:
-    #             return arg.to(self.device)
-    #     forward_args = list(map(move_to_device, range(len(forward_args)), forward_args))
-
-    #     # save parameters
-    #     self.forward_args[stage_id] = forward_args
-    #     self.stage_id = stage_id
-    #     self.input_idxs[stage_id] = input_idxs
-
-    #     for i in self.input_idxs[stage_id]:
-    #         self.forward_input_meta[stage_id][i] = (
-    #             forward_args[i].shape,
-    #             forward_args[i].dtype,
-    #             forward_args[i].requires_grad,
-    #         )
-    #         self.forward_args[stage_id][i] = None
-
-    #     # prepare tensors with DP comm ops
-    #     if not self.naive_gradient_sync and self.dp_degree > 1:
-    #         self._prepare_dp_comm_ops(stage_id)
-
-    #     # add the parameters to the optimizer for this stage
-    #     params = [param for param in forward_args if param is not None and param.requires_grad]
-    #     if stage_id not in self.optims:
-    #         self.optims[stage_id] = self.optim_class(params)
-    #     else:
-    #         self.optims[stage_id].add_param_group({"params": params})
-
-    #     del gm_data
     def _load_stage(self, stage_id: int, gm_data, forward_args, input_idxs):
         self.logger.debug(f"Loading stage {stage_id} graph on actor {self.global_rank}")
 
@@ -409,7 +364,7 @@ class PiperActor:
         realized = [None] * len(meta_args)
 
         g = torch.Generator(device=self.device)
-        g.manual_seed(0 + 1000 * self.global_rank + stage_id)
+        g.manual_seed(1000 * self.global_rank + stage_id)
 
         for i, arg in enumerate(meta_args):
             if arg is None:
@@ -428,7 +383,7 @@ class PiperActor:
         self.forward_args[stage_id] = realized
         self.stage_materialized[stage_id] = True
 
-        # Now safe to setup hooks + optimizer
+        # It's safe to setup hooks + optimizer after tensors are materialized
         if not self.naive_gradient_sync and self.dp_degree > 1:
             self._prepare_dp_comm_ops(stage_id)
 

--- a/src/piper_compile.py
+++ b/src/piper_compile.py
@@ -103,11 +103,13 @@ def order_p2p_comms(schedule: Schedule2D, num_devices: int, num_stages: int, sta
 
 
 def piper_setup(
-    model,
-    optim_fn,
-    example_inputs,
-    example_outputs,
-    schedule: Schedule2D,
+    model_class,
+    model_args=(),
+    model_kwargs={},
+    optim_fn=None,
+    example_inputs=None,
+    example_outputs=None,
+    schedule: Schedule2D=None,
     naive_gradient_sync=False,
 ):
     """
@@ -132,9 +134,9 @@ def piper_setup(
         num_devices, optim_fn, num_mbs, num_stages, p2p_schedules, naive_gradient_sync
     )
 
-    last_stage_rank = stage_to_device[num_stages - 1]
-    ray.get(piper_metadata.actors[0].load_input.remote(example_inputs))
-    ray.get(piper_metadata.actors[last_stage_rank].load_labels.remote(example_outputs))
+    # last_stage_rank = stage_to_device[num_stages - 1]
+    # ray.get(piper_metadata.actors[0].load_input.remote(example_inputs))
+    # ray.get(piper_metadata.actors[last_stage_rank].load_labels.remote(example_outputs))
 
     ray.get(
         [
@@ -143,12 +145,45 @@ def piper_setup(
         ]
     )
 
+    # Build the model on meta device
+    with torch.device("meta"):
+        model = model_class(*model_args, **model_kwargs)
+
     compiled = torch.compile(model, backend=piper)
 
     dp_rank = int(os.environ["PIPER_DP_RANK"])
-    logger.info(f"DP rank {dp_rank+1} compiling...")
+    logger.info(f"DP rank {dp_rank+1} compiling (meta)...")
 
-    output = compiled(*example_inputs)
+    # Create meta tensors from our example_inputs to pass to the compiled graph
+    # meta_inputs = [torch.empty_like(t, device="meta") for t in example_inputs]
+    meta_inputs = [x.to(device="meta") for x in example_inputs]
+
+    # # 1) Verify meta model params are actually meta
+    # for n, p in model.named_parameters():
+    #     assert p.device.type == "meta", (n, p.device)
+
+    # for n, b in model.named_buffers():
+    #     assert b.device.type == "meta", (n, b.device)
+
+    # # 2) Verify meta inputs
+    # for i, x in enumerate(meta_inputs):
+    #     assert isinstance(x, torch.Tensor)
+    #     assert x.device.type == "meta", (i, x.device)
+
+    _ = compiled(*meta_inputs)
+
+    logger.info(f"DP rank {dp_rank+1} stage graphs loaded onto actors.")
+
+    ray.get([
+        actor.materialize_all_stages.remote(init=init, seed=seed)
+        for actor in piper_metadata.actors.values()
+    ])
+    logger.info(f"DP rank {dp_rank+1} stages materialized on actors.")
+
+    last_stage_rank = stage_to_device[num_stages - 1]
+    ray.get(piper_metadata.actors[0].load_input.remote(example_inputs))
+    ray.get(piper_metadata.actors[last_stage_rank].load_labels.remote(example_outputs))
+    logger.info(f"DP rank {dp_rank+1} real inputs/labels loaded onto actors.")
 
     logger.info(f"DP rank {dp_rank+1} done.")
 

--- a/src/piper_compile.py
+++ b/src/piper_compile.py
@@ -175,7 +175,7 @@ def piper_setup(
     logger.info(f"DP rank {dp_rank+1} stage graphs loaded onto actors.")
 
     ray.get([
-        actor.materialize_all_stages.remote(init=init, seed=seed)
+        actor.materialize_all_stages.remote()
         for actor in piper_metadata.actors.values()
     ])
     logger.info(f"DP rank {dp_rank+1} stages materialized on actors.")

--- a/src/piper_compile.py
+++ b/src/piper_compile.py
@@ -134,10 +134,6 @@ def piper_setup(
         num_devices, optim_fn, num_mbs, num_stages, p2p_schedules, naive_gradient_sync
     )
 
-    # last_stage_rank = stage_to_device[num_stages - 1]
-    # ray.get(piper_metadata.actors[0].load_input.remote(example_inputs))
-    # ray.get(piper_metadata.actors[last_stage_rank].load_labels.remote(example_outputs))
-
     ray.get(
         [
             actor._join_process_groups.remote()
@@ -145,7 +141,7 @@ def piper_setup(
         ]
     )
 
-    # Build the model on meta device
+    # Build the model directly on meta device
     with torch.device("meta"):
         model = model_class(*model_args, **model_kwargs)
 
@@ -155,20 +151,7 @@ def piper_setup(
     logger.info(f"DP rank {dp_rank+1} compiling (meta)...")
 
     # Create meta tensors from our example_inputs to pass to the compiled graph
-    # meta_inputs = [torch.empty_like(t, device="meta") for t in example_inputs]
     meta_inputs = [x.to(device="meta") for x in example_inputs]
-
-    # # 1) Verify meta model params are actually meta
-    # for n, p in model.named_parameters():
-    #     assert p.device.type == "meta", (n, p.device)
-
-    # for n, b in model.named_buffers():
-    #     assert b.device.type == "meta", (n, b.device)
-
-    # # 2) Verify meta inputs
-    # for i, x in enumerate(meta_inputs):
-    #     assert isinstance(x, torch.Tensor)
-    #     assert x.device.type == "meta", (i, x.device)
 
     _ = compiled(*meta_inputs)
 

--- a/src/piper_graph_transform.py
+++ b/src/piper_graph_transform.py
@@ -118,6 +118,13 @@ def _dispatch_a2a_single(output: torch.Tensor, input_tensor: torch.Tensor) -> to
 # Allow the dispatch function in the graph
 torch.compiler.allow_in_graph(_dispatch_a2a_single)
 
+def _meta_tensor_like(example: torch.Tensor, *, requires_grad: bool, as_parameter: bool):
+    t = torch.empty(example.shape, dtype=example.dtype, device="meta")
+    t.requires_grad_(requires_grad)
+    if as_parameter:
+        return torch.nn.Parameter(t, requires_grad=requires_grad)
+    return t
+
 def _split_gm_by_stages(gm) -> tuple[fx.GraphModule, list[tuple[int, fx.GraphModule, list[int], list]]]:
     """
     Transform a graph module with stage annotations by extracting
@@ -455,10 +462,19 @@ def _split_gm_by_stages(gm) -> tuple[fx.GraphModule, list[tuple[int, fx.GraphMod
             prev_stage_outputs = set(prev_stage_outputs_list)
         
         for i, placeholder in enumerate(placeholders):
-            if "grapharg" in placeholder.meta:
-                graphargs.append(placeholder.meta["grapharg"]._example())
-            else:
-                graphargs.append(torch.zeros(placeholder.meta["example_value"].shape, dtype=placeholder.meta["example_value"].dtype, requires_grad=placeholder.meta["example_value"].requires_grad, device=placeholder.meta["example_value"].device))
+            ex = placeholder.meta["example_value"]
+
+            # Parameter-like placeholders
+            is_param_like = ("grapharg" in placeholder.meta) or ("self" in placeholder.name)
+
+            graphargs.append(
+                _meta_tensor_like(
+                    ex,
+                    requires_grad=bool(getattr(ex, "requires_grad", False)),
+                    as_parameter=is_param_like,
+                )
+            )
+
             # For the first stage, the input indices are everything that's not an attribute
             if stage_annotation_id == 0:
                 if 'self' not in placeholder.name:

--- a/src/piper_graph_transform.py
+++ b/src/piper_graph_transform.py
@@ -467,6 +467,8 @@ def _split_gm_by_stages(gm) -> tuple[fx.GraphModule, list[tuple[int, fx.GraphMod
             # Parameter-like placeholders
             is_param_like = ("grapharg" in placeholder.meta) or ("self" in placeholder.name)
 
+            # we may not actually need to call _metathis if we're already placing example inputs on meta, 
+            # but it's guaranteed to be safe with this function call
             graphargs.append(
                 _meta_tensor_like(
                     ex,

--- a/test/models/llama.py
+++ b/test/models/llama.py
@@ -401,15 +401,18 @@ class Transformer(nn.Module):
         )
         log_size(self.output)
 
-        self.freqs_cis = precompute_freqs_cis(
+        # Register freq_cis and mask as buffers so they are moved with the model
+        freqs_cis = precompute_freqs_cis(
             params.dim // params.n_heads,
             self.seq_len,
             params.rope_theta,
-        ).to('cuda')
+        )
+        self.register_buffer("freqs_cis", freqs_cis, persistent=False)
 
         mask = torch.full((self.seq_len, self.seq_len), float("-inf"))
         mask = torch.triu(mask, diagonal=1)
-        self.mask = torch.hstack([torch.zeros((self.seq_len, 0)), mask]).to('cuda')
+        mask = torch.hstack([torch.zeros((self.seq_len, 0)), mask])
+        self.register_buffer("mask", mask, persistent=False)
 
     """
     forward method for pp4-1f1b or pp2-interleaved-1f1b

--- a/test/models/llama.py
+++ b/test/models/llama.py
@@ -103,14 +103,14 @@ LLAMA_70B = ModelArgs(
     dim=8192,
     n_layers=80,
     n_heads=64,
-    n_kv_heads=8,          # GQA (Grouped Query Attention)
+    n_kv_heads=8,
     vocab_size=128256,
     multiple_of=4096,
     ffn_dim_multiplier=1.3,
     norm_eps=1e-5,
     rope_theta=500000,
     max_batch_size=32,
-    max_seq_len=8192,      # Llama 3 default context length
+    max_seq_len=8192,
 )
 
 
@@ -248,8 +248,6 @@ class Attention(nn.Module):
 
         xq, xk = apply_rotary_emb(xq, xk, freqs_cis=freqs_cis)
 
-        # print(f"xq is None: {xq is None}, xk is None: {xk is None}, xv is None: {xv is None}")
-
         # [NOTE] Disable KV cache during training.
 
         # self.cache_k = self.cache_k.to(xq)
@@ -277,9 +275,7 @@ class Attention(nn.Module):
         values = values.transpose(
             1, 2
         )  # (bs, n_local_heads, cache_len + seqlen, head_dim)
-        # print("Calculating scores")
         scores = torch.matmul(xq, keys.transpose(2, 3)) / math.sqrt(self.head_dim)
-        # print("Calculated scores")
         if mask is not None:
             scores = scores + mask  # (bs, n_local_heads, seqlen, cache_len + seqlen)
         scores = F.softmax(scores.float(), dim=-1).type_as(xq)
@@ -356,11 +352,8 @@ class TransformerBlock(nn.Module):
         freqs_cis: torch.Tensor,
         mask: Optional[torch.Tensor],
     ):
-        # print(f"TransformerBlock {self.layer_id} forward:")
         h = x + self.attention(self.attention_norm(x), start_pos, freqs_cis, mask)
-        # print(f"After attention: {h.shape}")
         out = h + self.feed_forward(self.ffn_norm(h))
-        # print(f"After feed forward: {out.shape}")
         return out
 
 
@@ -414,12 +407,10 @@ class Transformer(nn.Module):
             self.seq_len,
             params.rope_theta,
         )
-        # self.register_buffer("freqs_cis", freqs_cis, persistent=False)
 
         mask = torch.full((self.seq_len, self.seq_len), float("-inf"))
         mask = torch.triu(mask, diagonal=1)
         self.mask = torch.hstack([torch.zeros((self.seq_len, 0)), mask])
-        # self.register_buffer("mask", mask, persistent=False)
 
     """
     forward method for pp4-1f1b or pp2-interleaved-1f1b
@@ -459,34 +450,14 @@ class Transformer(nn.Module):
     # - n_layers is divisible by 2
     # """
     # def forward(self, tokens: torch.Tensor):
-    #     assert self.freqs_cis is not None, "freqs_cis is None"
-    #     assert self.mask is not None, "mask is None"
-    #     assert self.tok_embeddings is not None, "tok_embeddings is None"
-    #     assert self.layers is not None, "layers is None"
-    #     assert self.norm is not None, "norm is None"
-    #     assert self.output is not None, "output is None"
-    #     assert tokens is not None, "tokens is None"
-
-    #     # print(self.layers)
-
     #     with torch.fx.traceback.annotate({"stage": 0}):
     #         h = self.tok_embeddings(tokens)
     #         start_pos = 0
     #         for i, layer in enumerate(self.layers[:self.n_layers//2]):
-    #             # print(f"Stage 0, Layer {i}:")
-    #             # print(layer)
-    #             # print(f"freqs_cis shape: {self.freqs_cis.shape}")
-    #             # print(f"mask shape: {self.mask.shape}")
     #             h = layer(h, start_pos, self.freqs_cis, self.mask)
-
-    #     # print("Made it past stage 0 layers")
     #     with torch.fx.traceback.annotate({"stage": 1}):
-    #         # print("Iterating through stage 1")
-    #         # print(self.layers[self.n_layers//2:])
     #         for layer in self.layers[self.n_layers//2:]:
-    #             # print(layer)
     #             h = layer(h, start_pos, self.freqs_cis, self.mask)
-    #         # print(self.norm(h))
     #         h = self.norm(h)
     #         output = self.output(h).float()
 

--- a/test/models/llama.py
+++ b/test/models/llama.py
@@ -248,6 +248,8 @@ class Attention(nn.Module):
 
         xq, xk = apply_rotary_emb(xq, xk, freqs_cis=freqs_cis)
 
+        # print(f"xq is None: {xq is None}, xk is None: {xk is None}, xv is None: {xv is None}")
+
         # [NOTE] Disable KV cache during training.
 
         # self.cache_k = self.cache_k.to(xq)
@@ -275,7 +277,9 @@ class Attention(nn.Module):
         values = values.transpose(
             1, 2
         )  # (bs, n_local_heads, cache_len + seqlen, head_dim)
+        # print("Calculating scores")
         scores = torch.matmul(xq, keys.transpose(2, 3)) / math.sqrt(self.head_dim)
+        # print("Calculated scores")
         if mask is not None:
             scores = scores + mask  # (bs, n_local_heads, seqlen, cache_len + seqlen)
         scores = F.softmax(scores.float(), dim=-1).type_as(xq)
@@ -352,8 +356,11 @@ class TransformerBlock(nn.Module):
         freqs_cis: torch.Tensor,
         mask: Optional[torch.Tensor],
     ):
+        # print(f"TransformerBlock {self.layer_id} forward:")
         h = x + self.attention(self.attention_norm(x), start_pos, freqs_cis, mask)
+        # print(f"After attention: {h.shape}")
         out = h + self.feed_forward(self.ffn_norm(h))
+        # print(f"After feed forward: {out.shape}")
         return out
 
 
@@ -414,58 +421,76 @@ class Transformer(nn.Module):
         mask = torch.hstack([torch.zeros((self.seq_len, 0)), mask])
         self.register_buffer("mask", mask, persistent=False)
 
-    """
-    forward method for pp4-1f1b or pp2-interleaved-1f1b
-    requires:
-    - 4 devices
-    - 4 stages
-    - n_layers is divisible by 4
-    """
-    def forward(self, tokens: torch.Tensor):
-
-        with torch.fx.traceback.annotate({"stage": 0}):
-            h = self.tok_embeddings(tokens) if self.tok_embeddings else tokens
-            start_pos = 0
-            for layer in self.layers[:self.n_layers//4]:
-                h = layer(h, start_pos, self.freqs_cis, self.mask)
-
-        with torch.fx.traceback.annotate({"stage": 1}):
-            for layer in self.layers[self.n_layers//4:self.n_layers//2]:
-                h = layer(h, start_pos, self.freqs_cis, self.mask)
-
-        with torch.fx.traceback.annotate({"stage": 2}):
-            for layer in self.layers[self.n_layers//2:3*self.n_layers//4]:
-                h = layer(h, start_pos, self.freqs_cis, self.mask)
-
-        with torch.fx.traceback.annotate({"stage": 3}):
-            for layer in self.layers[3*self.n_layers//4:]:
-                h = layer(h, start_pos, self.freqs_cis, self.mask)
-            h = self.norm(h) if self.norm else h
-            output = self.output(h).float() if self.output else h
-
-        return output
-
     # """
-    # forward method for 1f1b schedule
+    # forward method for pp4-1f1b or pp2-interleaved-1f1b
     # requires:
-    # - 2 stages
-    # - n_layers is divisible by 2
+    # - 4 devices
+    # - 4 stages
+    # - n_layers is divisible by 4
     # """
     # def forward(self, tokens: torch.Tensor):
 
     #     with torch.fx.traceback.annotate({"stage": 0}):
-    #         h = self.tok_embeddings(tokens)
+    #         h = self.tok_embeddings(tokens) if self.tok_embeddings else tokens
     #         start_pos = 0
-    #         for layer in self.layers[:self.n_layers//2]:
+    #         for layer in self.layers[:self.n_layers//4]:
     #             h = layer(h, start_pos, self.freqs_cis, self.mask)
 
     #     with torch.fx.traceback.annotate({"stage": 1}):
-    #         for layer in self.layers[self.n_layers//2:]:
+    #         for layer in self.layers[self.n_layers//4:self.n_layers//2]:
     #             h = layer(h, start_pos, self.freqs_cis, self.mask)
-    #         h = self.norm(h)
-    #         output = self.output(h).float()
+
+    #     with torch.fx.traceback.annotate({"stage": 2}):
+    #         for layer in self.layers[self.n_layers//2:3*self.n_layers//4]:
+    #             h = layer(h, start_pos, self.freqs_cis, self.mask)
+
+    #     with torch.fx.traceback.annotate({"stage": 3}):
+    #         for layer in self.layers[3*self.n_layers//4:]:
+    #             h = layer(h, start_pos, self.freqs_cis, self.mask)
+    #         h = self.norm(h) if self.norm else h
+    #         output = self.output(h).float() if self.output else h
 
     #     return output
+
+    """
+    forward method for 1f1b schedule
+    requires:
+    - 2 stages
+    - n_layers is divisible by 2
+    """
+    def forward(self, tokens: torch.Tensor):
+        assert self.freqs_cis is not None, "freqs_cis is None"
+        assert self.mask is not None, "mask is None"
+        assert self.tok_embeddings is not None, "tok_embeddings is None"
+        assert self.layers is not None, "layers is None"
+        assert self.norm is not None, "norm is None"
+        assert self.output is not None, "output is None"
+        assert tokens is not None, "tokens is None"
+
+        # print(self.layers)
+
+        with torch.fx.traceback.annotate({"stage": 0}):
+            h = self.tok_embeddings(tokens)
+            start_pos = 0
+            for i, layer in enumerate(self.layers[:self.n_layers//2]):
+                # print(f"Stage 0, Layer {i}:")
+                # print(layer)
+                # print(f"freqs_cis shape: {self.freqs_cis.shape}")
+                # print(f"mask shape: {self.mask.shape}")
+                h = layer(h, start_pos, self.freqs_cis, self.mask)
+
+        # print("Made it past stage 0 layers")
+        with torch.fx.traceback.annotate({"stage": 1}):
+            # print("Iterating through stage 1")
+            # print(self.layers[self.n_layers//2:])
+            for layer in self.layers[self.n_layers//2:]:
+                # print(layer)
+                h = layer(h, start_pos, self.freqs_cis, self.mask)
+            # print(self.norm(h))
+            h = self.norm(h)
+            output = self.output(h).float()
+
+        return output
 
     # """
     # forward method for no pp

--- a/test/models/llama.py
+++ b/test/models/llama.py
@@ -409,88 +409,88 @@ class Transformer(nn.Module):
         log_size(self.output)
 
         # Register freq_cis and mask as buffers so they are moved with the model
-        freqs_cis = precompute_freqs_cis(
+        self.freqs_cis = precompute_freqs_cis(
             params.dim // params.n_heads,
             self.seq_len,
             params.rope_theta,
         )
-        self.register_buffer("freqs_cis", freqs_cis, persistent=False)
+        # self.register_buffer("freqs_cis", freqs_cis, persistent=False)
 
         mask = torch.full((self.seq_len, self.seq_len), float("-inf"))
         mask = torch.triu(mask, diagonal=1)
-        mask = torch.hstack([torch.zeros((self.seq_len, 0)), mask])
-        self.register_buffer("mask", mask, persistent=False)
-
-    # """
-    # forward method for pp4-1f1b or pp2-interleaved-1f1b
-    # requires:
-    # - 4 devices
-    # - 4 stages
-    # - n_layers is divisible by 4
-    # """
-    # def forward(self, tokens: torch.Tensor):
-
-    #     with torch.fx.traceback.annotate({"stage": 0}):
-    #         h = self.tok_embeddings(tokens) if self.tok_embeddings else tokens
-    #         start_pos = 0
-    #         for layer in self.layers[:self.n_layers//4]:
-    #             h = layer(h, start_pos, self.freqs_cis, self.mask)
-
-    #     with torch.fx.traceback.annotate({"stage": 1}):
-    #         for layer in self.layers[self.n_layers//4:self.n_layers//2]:
-    #             h = layer(h, start_pos, self.freqs_cis, self.mask)
-
-    #     with torch.fx.traceback.annotate({"stage": 2}):
-    #         for layer in self.layers[self.n_layers//2:3*self.n_layers//4]:
-    #             h = layer(h, start_pos, self.freqs_cis, self.mask)
-
-    #     with torch.fx.traceback.annotate({"stage": 3}):
-    #         for layer in self.layers[3*self.n_layers//4:]:
-    #             h = layer(h, start_pos, self.freqs_cis, self.mask)
-    #         h = self.norm(h) if self.norm else h
-    #         output = self.output(h).float() if self.output else h
-
-    #     return output
+        self.mask = torch.hstack([torch.zeros((self.seq_len, 0)), mask])
+        # self.register_buffer("mask", mask, persistent=False)
 
     """
-    forward method for 1f1b schedule
+    forward method for pp4-1f1b or pp2-interleaved-1f1b
     requires:
-    - 2 stages
-    - n_layers is divisible by 2
+    - 4 devices
+    - 4 stages
+    - n_layers is divisible by 4
     """
     def forward(self, tokens: torch.Tensor):
-        assert self.freqs_cis is not None, "freqs_cis is None"
-        assert self.mask is not None, "mask is None"
-        assert self.tok_embeddings is not None, "tok_embeddings is None"
-        assert self.layers is not None, "layers is None"
-        assert self.norm is not None, "norm is None"
-        assert self.output is not None, "output is None"
-        assert tokens is not None, "tokens is None"
-
-        # print(self.layers)
 
         with torch.fx.traceback.annotate({"stage": 0}):
-            h = self.tok_embeddings(tokens)
+            h = self.tok_embeddings(tokens) if self.tok_embeddings else tokens
             start_pos = 0
-            for i, layer in enumerate(self.layers[:self.n_layers//2]):
-                # print(f"Stage 0, Layer {i}:")
-                # print(layer)
-                # print(f"freqs_cis shape: {self.freqs_cis.shape}")
-                # print(f"mask shape: {self.mask.shape}")
+            for layer in self.layers[:self.n_layers//4]:
                 h = layer(h, start_pos, self.freqs_cis, self.mask)
 
-        # print("Made it past stage 0 layers")
         with torch.fx.traceback.annotate({"stage": 1}):
-            # print("Iterating through stage 1")
-            # print(self.layers[self.n_layers//2:])
-            for layer in self.layers[self.n_layers//2:]:
-                # print(layer)
+            for layer in self.layers[self.n_layers//4:self.n_layers//2]:
                 h = layer(h, start_pos, self.freqs_cis, self.mask)
-            # print(self.norm(h))
-            h = self.norm(h)
-            output = self.output(h).float()
+
+        with torch.fx.traceback.annotate({"stage": 2}):
+            for layer in self.layers[self.n_layers//2:3*self.n_layers//4]:
+                h = layer(h, start_pos, self.freqs_cis, self.mask)
+
+        with torch.fx.traceback.annotate({"stage": 3}):
+            for layer in self.layers[3*self.n_layers//4:]:
+                h = layer(h, start_pos, self.freqs_cis, self.mask)
+            h = self.norm(h) if self.norm else h
+            output = self.output(h).float() if self.output else h
 
         return output
+
+    # """
+    # forward method for 1f1b schedule
+    # requires:
+    # - 2 stages
+    # - n_layers is divisible by 2
+    # """
+    # def forward(self, tokens: torch.Tensor):
+    #     assert self.freqs_cis is not None, "freqs_cis is None"
+    #     assert self.mask is not None, "mask is None"
+    #     assert self.tok_embeddings is not None, "tok_embeddings is None"
+    #     assert self.layers is not None, "layers is None"
+    #     assert self.norm is not None, "norm is None"
+    #     assert self.output is not None, "output is None"
+    #     assert tokens is not None, "tokens is None"
+
+    #     # print(self.layers)
+
+    #     with torch.fx.traceback.annotate({"stage": 0}):
+    #         h = self.tok_embeddings(tokens)
+    #         start_pos = 0
+    #         for i, layer in enumerate(self.layers[:self.n_layers//2]):
+    #             # print(f"Stage 0, Layer {i}:")
+    #             # print(layer)
+    #             # print(f"freqs_cis shape: {self.freqs_cis.shape}")
+    #             # print(f"mask shape: {self.mask.shape}")
+    #             h = layer(h, start_pos, self.freqs_cis, self.mask)
+
+    #     # print("Made it past stage 0 layers")
+    #     with torch.fx.traceback.annotate({"stage": 1}):
+    #         # print("Iterating through stage 1")
+    #         # print(self.layers[self.n_layers//2:])
+    #         for layer in self.layers[self.n_layers//2:]:
+    #             # print(layer)
+    #             h = layer(h, start_pos, self.freqs_cis, self.mask)
+    #         # print(self.norm(h))
+    #         h = self.norm(h)
+    #         output = self.output(h).float()
+
+    #     return output
 
     # """
     # forward method for no pp

--- a/test/models/llama.py
+++ b/test/models/llama.py
@@ -99,6 +99,20 @@ LLAMA_8B = ModelArgs(
     max_seq_len=2048,
 )
 
+LLAMA_70B = ModelArgs(
+    dim=8192,
+    n_layers=80,
+    n_heads=64,
+    n_kv_heads=8,          # GQA (Grouped Query Attention)
+    vocab_size=128256,
+    multiple_of=4096,
+    ffn_dim_multiplier=1.3,
+    norm_eps=1e-5,
+    rope_theta=500000,
+    max_batch_size=32,
+    max_seq_len=8192,      # Llama 3 default context length
+)
+
 
 class RMSNorm(torch.nn.Module):
     def __init__(self, dim: int, eps: float = 1e-6):

--- a/test/test_llama.py
+++ b/test/test_llama.py
@@ -40,9 +40,6 @@ def main(args):
     print(args) 
 
     loss_fn = torch.nn.CrossEntropyLoss()
-    
-    # model = Transformer(llama_config, args.seq_len)
-    # model.to('cuda')
 
     x = torch.randint(0, llama_config.vocab_size, (args.batch_size, args.seq_len)).to('cuda')
     y = torch.randn((args.batch_size, args.seq_len, llama_config.vocab_size)).to('cuda')

--- a/test/test_llama.py
+++ b/test/test_llama.py
@@ -38,8 +38,8 @@ def main(args):
 
     loss_fn = torch.nn.CrossEntropyLoss()
     
-    model = Transformer(llama_config, args.seq_len)
-    model.to('cuda')
+    # model = Transformer(llama_config, args.seq_len)
+    # model.to('cuda')
 
     x = torch.randint(0, llama_config.vocab_size, (args.batch_size, args.seq_len)).to('cuda')
     y = torch.randn((args.batch_size, args.seq_len, llama_config.vocab_size)).to('cuda')
@@ -60,15 +60,16 @@ def main(args):
     print_schedule(schedule)
 
     piper_setup(
-        model,
-        torch.optim.Adam, 
-        [x],
-        y,
-        schedule,
-        args.naive_gradient_sync,
+        Transformer,
+        model_args=(llama_config, args.seq_len),
+        optim_fn=torch.optim.Adam,
+        example_inputs=[x],
+        example_outputs=y,
+        schedule=schedule,
+        naive_gradient_sync=args.naive_gradient_sync,
     )
 
-    del model
+    # del model
     del x
     del y 
     gc.collect()

--- a/test/test_llama.py
+++ b/test/test_llama.py
@@ -9,8 +9,9 @@ import gc
 from src.piper_exec import piper_exec
 from src.piper_compile import piper_setup, piper_shutdown
 from src.piper_coordinator import PiperProgramCoordinator
+from src.piper_utils import piper_metadata
 
-from .models.llama import Transformer, LLAMA_DEBUG, LLAMA_1B, LLAMA_3B, LLAMA_8B
+from .models.llama import Transformer, LLAMA_DEBUG, LLAMA_1B, LLAMA_3B, LLAMA_8B, LLAMA_70B
 from .schedule_helpers import (
     build_1f1b_schedule, 
     build_gpipe_schedule, 
@@ -34,6 +35,8 @@ def main(args):
             llama_config = LLAMA_3B
         case '8b':
             llama_config = LLAMA_8B
+        case '70b':
+            llama_config = LLAMA_70B
     print(args) 
 
     loss_fn = torch.nn.CrossEntropyLoss()
@@ -98,13 +101,13 @@ def main(args):
     )
 
     if args.tracing:
-        ray.get([actor.set_tracing.remote(args.tracing) for actor in actors.values()])
+        ray.get([actor.set_tracing.remote(args.tracing) for actor in piper_metadata.actors.values()])
 
         print(f"Running {args.warmup} tracing iterations...")
         for _ in range(args.warmup):
             piper_exec(schedule, loss_fn, args.dp, args.naive_gradient_sync)
 
-        trace_data_ret = ray.get([actor.get_trace_data.remote() for actor in actors.values()])
+        trace_data_ret = ray.get([actor.get_trace_data.remote() for actor in piper_metadata.actors.values()])
         for rank, trace_data in trace_data_ret:
             for key in trace_data:
                 all_times = trace_data[key]
@@ -122,8 +125,8 @@ def main(args):
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Run LLaMA model with pipeline parallelism')
-    parser.add_argument('--model', choices=['debug', '1b', '3b', '8b'], default='debug',
-                        help='Model configuration: debug, 1b, 3b, or 8b (default: debug)')
+    parser.add_argument('--model', choices=['debug', '1b', '3b', '8b', '70b'], default='debug',
+                        help='Model configuration: debug, 1b, 3b, 8b, or 70b (default: debug)')
     parser.add_argument('--schedule', choices=['gpipe', '1f1b', 'interleaved-1f1b', 'dualpipev', 'no-pp'], default='1f1b',
                         help='Schedule type: gpipe, 1f1b, interleaved-1f1b, dualpipev, or no-pp (default: 1f1b)')
     parser.add_argument('--dp', type=int, default=1,

--- a/test/test_tracing.py
+++ b/test/test_tracing.py
@@ -1,0 +1,240 @@
+import torch
+import torch.fx as fx
+import time
+import logging
+from .models.llama import Transformer, LLAMA_DEBUG, LLAMA_1B, LLAMA_8B, LLAMA_70B
+from src.piper_compile import piper_setup
+from src import piper as piper_backend
+from src.piper_utils import piper_metadata
+import ray
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def test_meta_device_compile():
+    """Test torch.compile on Llama model using meta device."""
+    logger.info("Testing torch.compile on Llama model with meta device...")
+    
+    config = LLAMA_70B
+    seq_len = 256
+    batch_size = 16
+    
+    try:
+        # Create model on meta device to avoid allocating memory
+        with torch.device("meta"):
+            start = time.perf_counter()
+            model = Transformer(config, seq_len)
+            end = time.perf_counter()
+            logger.info("✓ Model created on meta device")
+            logger.info(f"Model creation time: {(end - start)*1e3:.0f} ms")
+            
+        # Create dummy inputs on meta device
+        tokens = torch.randint(0, config.vocab_size, (batch_size, seq_len), device="meta")
+        logger.info(f"✓ Dummy tokens created on meta device: shape {tokens.shape}")
+        
+        # Compile the model on meta device
+        start = time.perf_counter()
+        compiled_model = torch.compile(model)
+        end = time.perf_counter()
+        logger.info("✓ torch.compile succeeded on meta device model")
+        logger.info(f"Compilation time: {(end - start)*1e3:.0f} ms")
+                
+        try:
+            output = compiled_model(tokens)
+            logger.info(f"✓ Inference successful on meta device, output shape: {output.shape}")
+        except Exception as e:
+            import traceback
+            tb = traceback.format_exc()
+            err_type = type(e).__name__
+            err_msg = str(e)
+            # Log detailed information for debugging
+            logger.warning(
+                f"⚠ Forward pass on meta device produced error (expected): {err_type}: {err_msg}\n{tb}"
+            )
+            # Add short hints for common error types
+            if isinstance(e, KeyError):
+                logger.warning(f"  Missing key in mapping: {e.args}")
+            elif isinstance(e, TypeError):
+                logger.warning(f"  TypeError details: args={e.args}")
+            elif isinstance(e, RuntimeError):
+                logger.warning(f"  RuntimeError details: args={e.args}")
+            
+        return True
+    except Exception as e:
+        logger.error(f"✗ Meta device compile test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_meta_device_fx_trace():
+    """Test torch.fx.symbolic_trace on Llama model using meta device."""
+    logger.info("\nTesting torch.fx.symbolic_trace on Llama model with meta device...")
+    
+    config = LLAMA_DEBUG
+    seq_len = 128
+    batch_size = 1
+    
+    try:
+        # Create model on meta device
+        model = Transformer(config, seq_len).to("meta")
+        logger.info("✓ Model created on meta device")
+        model.eval()
+        
+        # Create dummy inputs on meta device
+        tokens = torch.randint(0, config.vocab_size, (batch_size, seq_len), device="meta")
+        logger.info(f"✓ Dummy tokens created on meta device: shape {tokens.shape}")
+        
+        # Attempt symbolic tracing with meta device
+        traced_model = fx.symbolic_trace(model)
+        logger.info("✓ torch.fx.symbolic_trace succeeded")
+        logger.info(f"✓ Graph has {len(list(traced_model.graph.nodes))} nodes")
+        
+        return True
+    except Exception as e:
+        logger.error(f"✗ torch.fx.symbolic_trace failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_meta_device_graph_module():
+    """Test creating a GraphModule from meta device model."""
+    logger.info("\nTesting GraphModule creation with meta device...")
+    
+    config = LLAMA_8B
+    seq_len = 128
+    batch_size = 1
+    
+    try:
+        # Create model on meta device
+        model = Transformer(config, seq_len).to("meta")
+        logger.info("✓ Model created on meta device")
+        model.eval()
+        
+        # Try to trace and examine the computation graph
+        tokens = torch.randint(0, config.vocab_size, (batch_size, seq_len), device="meta")
+        
+        # Use torch._dynamo to trace the model
+        traced = torch.compile(model, backend="eager", fullgraph=False)
+        logger.info("✓ Model compiled with torch.compile on meta device")
+        
+        # Get model info
+        num_params = sum(p.numel() for p in model.parameters())
+        logger.info(f"✓ Model has {num_params:,} parameters")
+        
+        return True
+    except Exception as e:
+        logger.error(f"✗ GraphModule test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+if __name__ == "__main__":
+    logger.info("Starting Llama symbolic tracing with meta device...\n")
+    
+    results = {
+        "torch.compile (meta)": test_meta_device_compile(),
+        # "torch.fx.symbolic_trace (meta)": test_meta_device_fx_trace(),
+        # "GraphModule (meta)": test_meta_device_graph_module(),
+        # "piper_backend (meta)": False,
+    }
+
+    def test_piper_backend_meta():
+        """Quick smoke test that calls the piper backend setup (no schedule execution)."""
+        logger.info("\nTesting piper backend setup with meta device...")
+        config = LLAMA_DEBUG
+        seq_len = 128
+        batch_size = 1
+        try:
+            # dummy input shapes (on cpu) are sufficient for piper_setup
+            x = torch.randint(0, config.vocab_size, (batch_size, seq_len))
+            # call piper setup which prepares the pipeline/actors
+            compiled = piper_setup(Transformer, (config, seq_len), torch.optim.Adam, [x], 2, 2)
+            logger.info("✓ piper_setup completed (no schedule run)")
+            return True
+        except Exception as e:
+            logger.error(f"✗ piper backend setup failed: {e}")
+            import traceback
+            traceback.print_exc()
+            return False
+
+    # run piper backend smoke test last (it may start actors)
+    # results["piper_backend (meta)"] = test_piper_backend_meta()
+
+    def test_piper_backend_meta_graph():
+        """Compile the model with the `piper` torch.compile backend on meta device.
+
+        This attempts to invoke the backend compilation path to produce serialized
+        graphmodules without requiring real Ray actors or GPUs by monkeypatching
+        a minimal actor handle and `ray.get`.
+        """
+        logger.info("\nTesting piper backend as torch.compile backend with meta device...")
+        config = LLAMA_DEBUG
+        seq_len = 128
+
+        # Build model on meta device
+        model = Transformer(config, seq_len).to("meta")
+
+        # Prepare example input on meta device
+        tokens = torch.randint(0, config.vocab_size, (1, seq_len), device="meta")
+
+        # Save original ray.get to restore later
+        orig_ray_get = ray.get
+        try:
+            # Set minimal piper metadata to allow backend to run
+            piper_metadata.currently_compiling = True
+            piper_metadata.current_stage = 0
+            piper_metadata.current_actor = 0
+            piper_metadata.first_graph_of_stage = True
+
+            # Create a minimal dummy actor handle with a .load_graph.remote
+            class _DummyLoad:
+                def remote(self, *a, **k):
+                    return None
+
+            class _DummyActor:
+                def __init__(self):
+                    self.load_graph = _DummyLoad()
+
+            piper_metadata.actors = {0: _DummyActor()}
+
+            # Monkeypatch ray.get so it accepts our dummy return value
+            ray.get = lambda x: x
+
+            # Compile with piper backend (this will call into src.piper.piper)
+            compiled = torch.compile(model, backend=piper_backend.piper)
+            logger.info("✓ torch.compile returned a compiled function (piper backend)")
+
+            # Call compiled to trigger backend handling (serialization/loading)
+            try:
+                _ = compiled(tokens)
+                logger.info("✓ Invoked compiled function (backend path exercised)")
+            except Exception:
+                # It's acceptable for the runtime invocation to raise when using meta tensors;
+                # the important part is that the backend path executed during compilation.
+                logger.info("⚠ Invocation raised during meta-device run (expected) — compilation path exercised")
+
+            return True
+        except Exception as e:
+            logger.error(f"✗ piper backend meta compile failed: {e}")
+            import traceback
+            traceback.print_exc()
+            return False
+        finally:
+            # restore
+            ray.get = orig_ray_get
+            piper_metadata.currently_compiling = False
+            piper_metadata.actors = {}
+
+    # results["piper_backend_graph (meta)"] = test_piper_backend_meta_graph()
+    
+    logger.info("\n" + "="*60)
+    logger.info("Test Results Summary:")
+    for test_name, result in results.items():
+        status = "✓ PASS" if result else "✗ FAIL"
+        logger.info(f"  {test_name}: {status}")
+    logger.info("="*60)

--- a/test/test_tracing.py
+++ b/test/test_tracing.py
@@ -68,6 +68,55 @@ def test_meta_device_compile():
         traceback.print_exc()
         return False
 
+def test_meta_device_fake_tensor():
+    """Test torch.compile on Llama model using meta params + fake inputs."""
+    logger.info("Testing torch.compile on Llama model with meta device + fake inputs...")
+
+    config = LLAMA_70B
+    seq_len = 256
+    batch_size = 16
+
+    try:
+        # Create model on meta device to avoid allocating memory
+        with torch.device("meta"):
+            start = time.perf_counter()
+            model = Transformer(config, seq_len)
+            end = time.perf_counter()
+            logger.info("✓ Model created on meta device")
+            logger.info(f"Model creation time: {(end - start)*1e3:.0f} ms")
+
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        fake_mode = FakeTensorMode(allow_non_fake_inputs=False)
+
+        trace_device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+
+        # Create fake tokens (no storage) that pretend to be on trace_device
+        with fake_mode:
+            tokens = torch.empty((batch_size, seq_len), dtype=torch.long, device=trace_device)
+            logger.info(f"✓ Fake tokens created: shape={tuple(tokens.shape)} device={tokens.device} type={type(tokens)}")
+
+            start = time.perf_counter()
+            compiled_model = torch.compile(model)
+            end = time.perf_counter()
+            logger.info("✓ torch.compile succeeded (meta model + fake inputs)")
+            logger.info(f"Compilation time: {(end - start)*1e3:.0f} ms")
+
+            try:
+                output = compiled_model(tokens)
+                # output may also be fake
+                logger.info(f"✓ Forward pass succeeded, output shape: {tuple(output.shape)}")
+            except Exception as e:
+                import traceback
+                tb = traceback.format_exc()
+                logger.warning(f"⚠ Forward pass produced error (still useful): {type(e).__name__}: {e}\n{tb}")
+
+        return True
+
+    except Exception as e:
+        logger.error(f"✗ Meta+fake compile test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
 
 def test_meta_device_fx_trace():
     """Test torch.fx.symbolic_trace on Llama model using meta device."""
@@ -138,6 +187,7 @@ if __name__ == "__main__":
     
     results = {
         "torch.compile (meta)": test_meta_device_compile(),
+        # "torch.compile + fake tensors (meta)": test_meta_device_fake_tensor(),
         # "torch.fx.symbolic_trace (meta)": test_meta_device_fx_trace(),
         # "GraphModule (meta)": test_meta_device_graph_module(),
         # "piper_backend (meta)": False,


### PR DESCRIPTION
- Changed the `piper_setup` API to use model_configs and constructor arguments instead of passing the model itself
- Build and compile the model on `torch.device("meta")` to avoid OOM issues with models that can't fit on a single GPU
- `piper_setup` makes a separate API call to materialize the actual tensors on actors after doing a forward pass on the compiled model