### PR TITLE
DP fault tolerance: health monitoring, standby ranks, NIXL weight transfer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ out/
 .vscode/
 .codex
 ec2-trust-policy.json
-piper_study/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ out/
 .vscode/
 .codex
 ec2-trust-policy.json
+piper_study/

--- a/design_docs/health_monitoring.md
+++ b/design_docs/health_monitoring.md
@@ -1,0 +1,59 @@
+# Design
+
+1. Driver — piper_exec_dag (the only real change):
+
+run_refs = [actor.run_dag.remote(loss_fn=loss_fn) for actor in actors.values()]
+while True:
+    try:
+        results = ray.get(run_refs, timeout=step_timeout)   # SAME refs each retry
+        break
+    except ray.exceptions.GetTimeoutError:
+        print("step exceeded timeout; still waiting (peer may be down)")
+        # loop — do NOT resubmit run_dag, do NOT return anything
+# ... rest of the function unchanged
+
+No PENDING, no signature change, no changes to the results loop. RayActorError/RayTaskError need no except at all — uncaught exceptions already propagate.
+
+Pass the timeout only after warmup (we assume warmup does not fail)
+
+step_timeout: None during warmup; then 5 × measured steady step time.
+
+2. test_qwen.main — no changes. Your "wrapped with try…except…raise" is a no-op: an exception from piper_exec_dag already flies up and fails the task. That's Python doing your escalation for free. (Add a try/except only if you want a log line.)
+
+3. Coordinator — run_program monitors outcomes:
+
+refs = [run_dp_rank.options(...).remote(dp_rank, ...) for dp_rank in range(self.dp_degree)]
+pending, results, failures = refs, [], 0
+while pending:
+    done, pending = ray.wait(pending, num_returns=1)    # whoever finishes/fails FIRST
+    try:
+        results.append(ray.get(done[0]))
+    except Exception as e:
+        failures += 1
+        print(f"a dp_rank failed ({failures}/{self.dp_degree}): {e}")
+        if failures == self.dp_degree:
+            raise                                       # everyone's down → job over
+return results
+
+One knock-on: run_program now returns results instead of handles, so the harness's double-ray.get becomes a single ray.get(coordinator.run_program.remote(...)) — a one-line change in test_harness.py.
+
+With the coordinator now tolerating the first failure, the loud test's total runtime = the survivor's NCCL watchdog (~10–30 min), because "wait for the standby" waits for something that doesn't exist yet. For milestone 1 I'd make it a policy flag:
+
+if failures and not STANDBY_ENABLED:   # M1: no standby exists
+    raise                              # fail fast; waiting buys nothing yet
+
+— fast tests now, and the STANDBY_ENABLED branch is the marked socket where the next milestone plugs in.
+
+# Test
+
+E2E test, in BWD, add a global counter, in the second iteration (past warmup), add an error. in one DP worker. Test with GPU 1 and 2 (cuda_visible_device).
+
+```python
+# in case TaskType.BWD, executors.py
+if os.environ.get("PIPER_FAULT") == f"bwd:{self._iter_count}:{self.runtime.dp_rank}":
+    raise RuntimeError("injected fault")        # loud mode
+    # or: time.sleep(x)                    # stuck mode — tests the timeout arm
+```
+
+self._iter_count should be a global counter just for debugging this and not in production.
+

--- a/design_docs/standby_worker.md
+++ b/design_docs/standby_worker.md
@@ -1,0 +1,66 @@
+Goal:
+Add a standby DP rank. When a rank fails, swap in the DP rank and copy the weights and optimizer state of the survived rank. On which step to redo: failure before UPD → survivors are still at N−1 → copy and redo step N; failure inside UPD → survivor states may differ → copy from one survivor and continue. The standby rank can do initialization at first.
+
+Breakdown:
+1. Try to start a rank standby
+    - world_size now equals dp_degree * pp_degree + standby ranks
+    - Add a CPU+GPU bundle for the standby rank. This means the GPU is reserved.
+    - When creating dp groups, do not involve the standby rank.
+    - a coordinator change — the parked standby's `run_dp_rank` task never finishes, so M1's `run_program` loop (`while pending: ray.wait…`) must exclude it from its accounting, or a clean 2-DP run never terminates and fail-fast miscounts `failures/n`.
+
+2. But let rank standby wait for running iterations 
+    - Effectively start the driver first. 
+    - test_qwen.py: if rank standby, pause at `logger.info(f"Running {args.warmup} warmup iterations")`
+    - To realise the pause:
+        ```python
+        @ray.remote
+        class PromotionSignal:
+            def __init__(self): self.cmd = None
+            def set(self, cmd): self.cmd = cmd          # coordinator calls this
+            def get(self): return self.cmd              # standby polls this
+
+        # standby's pause, inside test_qwen.main right after piper_setup:
+        # the standby can block on a long-poll method (ray.get(sig.wait_for_cmd.remote()) with the coordinator resolving it)
+        # cmd tells it: which rank to become, who to copy weights from
+        ```
+    - The coordinator (which already detects failures in its ray.wait loop — no extra daemon thread needed for this) just calls sig.set.remote({...}) when it decides to promote.
+        - Order: set PromotionSignal → then abort.
+
+3. If fail, let rank standby start from the failed iterations
+    - The survivor finishes UPD naturally and blocks at N+1's REDUCE
+    - Add a commit stage (a which iteration indicator) after UPD's cuda sync
+    - Abort the survivor's comm wherever it is → read its commit marker → everyone redoes step last_committed + 1 on the new group.
+    - Let the survivor stops at N+1's ALL-REDUCE and in the meantime, the standby copies the survivor's weights. (begins to Phase 2, do not worry now)
+    - When fail happens:
+        ```python
+        _abort_process_group(dp_group) # also ep_group
+        new_dp = dist.new_group(ranks=[0, 2], use_local_synchronization=True)
+        ```
+    - Who executes what: `_abort_process_group` — survivor only (the standby has no dp/ep group to abort); `new_group` — survivor **and** standby, and only them (local-sync rule: members call, nobody else). Both lines run actor-side, triggered after the PromotionSignal is set.
+    - Survivor:
+        ```python
+        except ray.exceptions.RayTaskError as e:
+        if ray.get(sig.get.remote()) is not None:      # promotion in progress → I was fenced
+            logger.info("fenced by coordinator; waiting for rebuild")
+            wait_for_rebuild_and_reissue()             # actor rebuilds groups, then re-fire run_dag
+        else:
+            raise                                       # genuine failure → M1 behavior unchanged
+        ```
+
+Phase 1 implementation: 
+- Don't replace the failed replica with rank standby.
+    - Do not need to transfer weights through CUDA-IPC.
+    - So the standby prints "ready to receive weights". Then it is safe to stop the test.
+- Phase 2, do not worry now
+    - Standby reads survivor's buffers via CUDA IPC (later RDMA/NIXL), overlapped with detection, no survivor involvement.
+    - Survivor's iteration and weight transfer should happen in parallel.
+    -  RuntimeState rank remap at promotion, standby's iteration-counter alignment, data-shard adoption.
+
+
+Testing plan:
+- At init, the standby worker should finish init and the regular ranks should work correctly. And results.csv identical to a no-standby run. 
+- Same failure mechanism as `/m-coriander/coriander/stfeng/piper/design_docs/health_monitoring.md`. (promotion is enabled by --num-standby > 0; PIPER_STANDBY_ENABLED was removed as redundant)
+- At failure, the standby and the survivor should join a NCCL group.
+- At failure, the standby should print "ready to receive weights".
+
+> **[Claude]:** Phase 1 implemented and all tests above pass (2026-08-01, 3× H200; plus M1 regressions and the 18 CPU tests). See `docs/standby_worker.md` for knobs, commands, and evidence. Two deviations from this doc, both forced by verified failure modes: (1) the fence needed to be stronger than "abort the comm" — an aborted collective *releases* its kernels with garbage and the pre-enqueued optimizer step would commit poisoned weights (observed empirically: marker advanced past the fault), so in standby mode UPD CPU-syncs all-reduces and refuses the step when fenced; (2) `join_standby_group` must wait for `abort_comms` to fully finish and actors must run with `TORCH_NCCL_ASYNC_ERROR_HANDLING=0` (per `_abort_process_group`'s own docs) — otherwise the fresh survivor+standby comm init deadlocks against the in-flight abort/watchdog. Also note: with the commit marker in place, `last_committed` correctly reads 3 at a fault injected in iteration 4, i.e. "redo iteration 4" — the marker, not the survivor's error text (which is timing-dependent), carries the recovery semantics.

--- a/design_docs/weight_transfer.md
+++ b/design_docs/weight_transfer.md
@@ -1,0 +1,46 @@
+# test_qwen.py:
+
+def _run_standby(dp_rank):
+    original codes + registers its buffers while parked
+    if promote:
+        join_standby_group
+        I = ray.get(standby_actor.wait_state_loaded.remote())
+        for _ in range(args.iters) --> calculate with I:
+            piper_exec_dag(xxx)
+    else:
+        original codes
+
+def main(args, pg):
+    turn `for _ in range(args.iters):` into `while True` + iter counting
+    warp piper_exec_dag with "try ... except"
+        except "Ready to continue" --> modify iter counting
+
+# piper.py:
+    
+def piper_exec_dag(loss_fn, log_stats: bool = False, step_timeout: float | None = None) -> list:
+    original codes until `except (ray.exceptions.RayTaskError, ray.exceptions.RayActorError) as e:`
+        join_standby_group
+        ref = survivor_actor.get_state.remote()              # produce (nixl); let I = last_committed+1 ride inside get_state's return; get_state must include optimizer state (Adam exp_avg/exp_avg_sq/step), not just weights
+        ray.get(standby_actor.load_state.remote([ref]))      # standby receives
+        del ref
+        raise "Ready to continue"
+
+# actor.py
+
+def join_standby_group(self, new_ranks):
+    change `self.runtime.standby_dp_group` to `self.runtime.dp_group`
+    set unfenced
+
+Limitations:
+1. standby worker not recorded with metrics
+2. Can only restart at start of an iteration
+
+Notes
+1. Docstrings state only what the API does and what each parameter means. Comments exist only for non-obvious "why"s, at most 1–2 lines each. Never narrate implementation mechanics anywhere.
+2. Do not commit anything
+3. For NIXL RDT, use the method in https://www.anyscale.com/blog/rdt-ray-direct-transport-fast-easy-weight-syncing-for-rl-reinforcement-learning
+
+Tests
+1. Create unit test for NIXL transfer
+2. E2E test with the automatic kill
+3. Record the precise timing and results correctness

--- a/docs/health_monitoring.md
+++ b/docs/health_monitoring.md
@@ -57,7 +57,8 @@ python examples/test_harness.py --test-file examples/test_qwen.py \
 
 Expected: `PIPER_FAULT firing`, coordinator logs `a dp_rank task failed (1/2)`
 with the `RuntimeError: injected fault` traceback, job exits nonzero within
-seconds.
+seconds. The driver stdout shows only the traceback; the other lines are in
+the Ray worker logs (`<temp-dir>/session_*/logs/worker-*.out`).
 
 **Stuck mode** — 60 s hang in dp_rank 1 (self-recovers):
 

--- a/docs/health_monitoring.md
+++ b/docs/health_monitoring.md
@@ -9,7 +9,7 @@ watchdog (~10–30 min). No recovery yet — standby promotion is the next miles
 ```
 harness (test_harness.py)
   └─ PiperProgramCoordinator.run_program          [src/coordinator.py]
-       ray.wait on dp_rank tasks (completion order)
+       async actor; awaits dp_rank tasks (completion order)
        ├─ 1st task failure → log "a dp_rank task failed (k/n)"
        │    └─ no standby configured → raise (fail fast) → job exits
        └─ driver, per dp_rank (test_qwen.main)

--- a/docs/health_monitoring.md
+++ b/docs/health_monitoring.md
@@ -11,7 +11,7 @@ harness (test_harness.py)
   └─ PiperProgramCoordinator.run_program          [src/coordinator.py]
        ray.wait on dp_rank tasks (completion order)
        ├─ 1st task failure → log "a dp_rank task failed (k/n)"
-       │    └─ STANDBY_ENABLED off → raise (fail fast) → job exits
+       │    └─ no standby configured → raise (fail fast) → job exits
        └─ driver, per dp_rank (test_qwen.main)
             └─ piper_exec_dag(..., step_timeout)  [src/piper.py]
                  ray.get(run_refs, timeout=step_timeout)
@@ -33,7 +33,7 @@ harness (test_harness.py)
 | Knob | Where | Meaning |
 |---|---|---|
 | `step_timeout` (param, seconds, default `None`) | `piper_exec_dag` | Warn when a step is overdue; `None` disables. `test_qwen.py` sets it automatically: `None` during warmup, then `max(5.0, 5 × last warmup step time)`. |
-| `PIPER_STANDBY_ENABLED` (env, default `0`) | coordinator | `0`: fail fast on first dp_rank failure. `1`: keep waiting until all dp_ranks fail (socket for the standby milestone). |
+| `--num-standby` (harness flag, default 0) | coordinator | `0`: fail fast on first dp_rank failure. `>0`: promote a standby instead (see `docs/standby_worker.md`). |
 | `PIPER_FAULT` (env, debug only) | `executors.py` BWD dispatch | Fault injection for tests; fires once per matching iteration and prints `PIPER_FAULT firing: <spec>`. Formats below. |
 
 `PIPER_FAULT` formats (`<iter>` is the 0-based `run_dag` counter; warmup counts):

--- a/docs/health_monitoring.md
+++ b/docs/health_monitoring.md
@@ -1,0 +1,94 @@
+# Health Monitoring (Milestone 1)
+
+Detects DP worker failures (crash or hang) during training and fails the job
+fast with a classified error, instead of hanging silently until the NCCL
+watchdog (~10–30 min). No recovery yet — standby promotion is the next milestone.
+
+## Architecture
+
+```
+harness (test_harness.py)
+  └─ PiperProgramCoordinator.run_program          [src/coordinator.py]
+       ray.wait on dp_rank tasks (completion order)
+       ├─ 1st task failure → log "a dp_rank task failed (k/n)"
+       │    └─ STANDBY_ENABLED off → raise (fail fast) → job exits
+       └─ driver, per dp_rank (test_qwen.main)
+            └─ piper_exec_dag(..., step_timeout)  [src/piper.py]
+                 ray.get(run_refs, timeout=step_timeout)
+                 ├─ GetTimeoutError → warn "step exceeded step_timeout",
+                 │                    keep waiting on the SAME step
+                 └─ RayTaskError / RayActorError → propagate → task fails
+                      └─ PiperActor.run_dag       [src/actor.py, executors.py]
+                           actor error or injected fault originates here
+```
+
+- Stuck and slow are indistinguishable at the driver (both are `GetTimeoutError`);
+  the driver only warns and waits. Loud errors escalate: actor → driver task →
+  coordinator → harness.
+- A hung *victim* is never detected in M1; the survivor's NCCL watchdog is the
+  backstop. Bounded hang detection requires heartbeats (later milestone).
+
+## User-facing knobs
+
+| Knob | Where | Meaning |
+|---|---|---|
+| `step_timeout` (param, seconds, default `None`) | `piper_exec_dag` | Warn when a step is overdue; `None` disables. `test_qwen.py` sets it automatically: `None` during warmup, then `max(5.0, 5 × last warmup step time)`. |
+| `PIPER_STANDBY_ENABLED` (env, default `0`) | coordinator | `0`: fail fast on first dp_rank failure. `1`: keep waiting until all dp_ranks fail (socket for the standby milestone). |
+| `PIPER_FAULT` (env, debug only) | `executors.py` BWD dispatch | Fault injection for tests; fires once per matching iteration and prints `PIPER_FAULT firing: <spec>`. Formats below. |
+
+`PIPER_FAULT` formats (`<iter>` is the 0-based `run_dag` counter; warmup counts):
+
+- `bwd:<iter>:<dp_rank>` — raise `RuntimeError` (loud mode)
+- `bwd:<iter>:<dp_rank>:sleep:<seconds>` — sleep in BWD (stuck mode)
+
+## Testing the behaviors
+
+Both tests: pure-DP2 schedule, 2 GPUs, default warmup=3 (iters 0–2), so iter 4
+is the second timed iteration.
+
+**Loud mode** — injected crash in dp_rank 1:
+
+```bash
+CUDA_VISIBLE_DEVICES=1,2 PIPER_FAULT=bwd:4:1 \
+python examples/test_harness.py --test-file examples/test_qwen.py \
+  --base-schedule examples/base-schedules/dp2.json \
+  --schedule 1f1b --ranks 1 --mbs 1
+```
+
+Expected: `PIPER_FAULT firing`, coordinator logs `a dp_rank task failed (1/2)`
+with the `RuntimeError: injected fault` traceback, job exits nonzero within
+seconds.
+
+**Stuck mode** — 60 s hang in dp_rank 1 (self-recovers):
+
+```bash
+CUDA_VISIBLE_DEVICES=1,2 PIPER_FAULT=bwd:4:1:sleep:60 \
+python examples/test_harness.py --test-file examples/test_qwen.py \
+  --base-schedule examples/base-schedules/dp2.json \
+  --schedule 1f1b --ranks 1 --mbs 1
+```
+
+Expected: both drivers repeat `step exceeded step_timeout=5.0s; still waiting`
+for ~60 s (victim and survivor are indistinguishable), then the run completes
+normally — exit 0, `results.csv` written, faulted iteration ≈ 60 s.
+
+Regression: `python -m pytest -m "not gpu" -v test` and any normal run without
+`PIPER_FAULT` are unaffected (`step_timeout=None` preserves old behavior).
+
+## Limitation: detection only — never which component or why
+
+M1 reports *that* a dp_rank task failed and the error that surfaced — **never
+which component is the root cause**. Do not read the coordinator's first
+failure report as attribution.
+
+Example (DP=2): GPU 1's NCCL driver wedges mid-all-reduce, process still alive.
+Both ranks hang — rank 1's kernel is wedged, rank 0's kernel spins waiting for
+it. Both drivers warn `step exceeded step_timeout`. Eventually each rank's own
+NCCL watchdog fires; the race is nondeterministic, and if rank 1's host-side
+NCCL is also impaired, only rank 0's watchdog fires. The coordinator then logs
+**the healthy GPU 0 as the first failure** while the sick GPU 1 dies second or
+never.
+
+Root-cause attribution needs evidence from below the training stack (e.g. Xid
+scan via `nvidia-smi -q` / `dmesg` per GPU, `NCCL_DEBUG=WARN` logs) and is out
+of scope for M1.

--- a/docs/standby_worker.md
+++ b/docs/standby_worker.md
@@ -1,0 +1,78 @@
+# Standby Worker (Phase 1)
+
+A standby DP rank reserves a GPU, fully initializes, parks before warmup, and
+on a trainer failure joins the survivor in a fresh NCCL group ("ready to
+receive weights"). Weight transfer and resume are Phase 2.
+
+## Architecture
+
+```
+ coordinator            driver dp0            driver dp1           driver dp2 (standby)
+ ───────────            ──────────            ──────────           ────────────────────
+ spawn drivers ───────► piper_setup           piper_setup          piper_setup (full init)
+ create PromotionSignal   register actors ──►   register actors ──►  register actors
+      │                 train loop            train loop           PARK on wait_for_cmd
+      │                 FWD BWD ═ALL-REDUCE═ FWD BWD ✗ fault              ⋮
+ ray.wait sees dp1's task fail ◄─────────────── task fails                ⋮
+      │ sig.set({promote, failed:1,                                       ⋮
+      │          source:0, new_ranks:[0,2]}) ────────────────────► wakes  │
+      │ abort_comms ──► fence flag → abort                                │
+      │                 dp+ep → abort_done                                │
+      │                 step errors → fenced arm                          │
+      │                 (signal names dp1, not me)                        │
+      │                 join_standby_group ◄═══ new group [0,2] ═══► join_standby_group
+      │                 sanity all-reduce = 2.0      │             sanity all-reduce = 2.0
+      │                 last_committed=3 →           │             print "ready to
+      │                 PiperFencedError →           │             receive weights" →
+      │                 return partial metrics       │             return
+ all refs resolved → return results → exit 0
+```
+
+No failure: coordinator sends `{op: shutdown}` after trainers finish; the
+standby wakes, exits; results.csv identical to a no-standby run.
+
+## Knobs
+
+| Knob | Where | Meaning |
+|---|---|---|
+| `--num-standby N` (default 0) | `test_harness.py` | Reserve N standby ranks (+N GPU bundles, `world_size = dp*pp + N`). N > 0 enables promotion on trainer failure; 0 keeps fail-fast. pp_degree must be 1. |
+| `PIPER_FAULT` (env, debug) | `executors.py` | Fault injection: `bwd:<iter>:<rank>` (crash) or `bwd:<iter>:<rank>:sleep:<s>` (stall). |
+
+## Tests
+
+```bash
+# failure -> promotion
+CUDA_VISIBLE_DEVICES=0,1,2 PIPER_FAULT=bwd:4:1 python examples/test_harness.py \
+  --test-file examples/test_qwen.py --base-schedule examples/base-schedules/dp2.json \
+  --schedule 1f1b --ranks 1 --mbs 1 --num-standby 1
+# -> promoting standby 2; fenced, optimizer step refused (last_committed=3);
+#    sanity_allreduce=2.0; "ready to receive weights"; exit 0 (~2 s fault->joined)
+```
+
+Result (2026-08-10, 3x H200, exit 0):
+
+```
+10:44:18.771  standby dp_rank 2: initialized and parked; waiting for promotion or shutdown
+10:44:31.919  Running 3 timed iterations
+              PIPER_FAULT firing: bwd:4:1
+10:44:31.979  a dp_rank task failed (1/2)
+10:44:31.980  promoting standby 2 for failed rank 1: {'op': 'promote', 'failed': 1,
+              'source': 0, 'new_ranks': [0, 2]}
+10:44:32.200  fenced by coordinator during promotion (step error: ... optimizer step
+              refused (last_committed=3))
+10:44:32.502  abort_comms: aborted ['dp_group', 'ep_group']
+10:44:34.391  join_standby_group: ranks=[0, 2] sanity_allreduce=2.0   (both actors)
+10:44:34.394  survivor: joined standby group [0, 2]; last_committed=3; recovery would
+              redo iteration 4
+              ready to receive weights
+              metrics written to out/20260810_104327/results.csv
+```
+
+Fault -> joined: ~2.4 s. End-of-run log lines can be lost to Ray's driver log
+forwarding; ground truth is `<ray_tmp>/session_*/logs/worker-*.out`.
+
+## Limitations
+
+- Promotion triggers on loud failures only; a silently hung rank is not
+  detected — and standby mode disables the NCCL watchdog backstop
+  (`TORCH_NCCL_ASYNC_ERROR_HANDLING=0`, required by `_abort_process_group`).

--- a/docs/standby_worker.md
+++ b/docs/standby_worker.md
@@ -10,11 +10,11 @@ receive weights"). Weight transfer and resume are Phase 2.
  coordinator            driver dp0            driver dp1           driver dp2 (standby)
  ───────────            ──────────            ──────────           ────────────────────
  spawn drivers ───────► piper_setup           piper_setup          piper_setup (full init)
- create PromotionSignal   register actors ──►   register actors ──►  register actors
+ cmd channel + registry   register actors ──►   register actors ──►  register actors
       │                 train loop            train loop           PARK on wait_for_cmd
       │                 FWD BWD ═ALL-REDUCE═ FWD BWD ✗ fault              ⋮
- ray.wait sees dp1's task fail ◄─────────────── task fails                ⋮
-      │ sig.set({promote, failed:1,                                       ⋮
+ asyncio.wait sees dp1's task fail ◄─────────── task fails                ⋮
+      │ set_cmd({promote, failed:1,                                       ⋮
       │          source:0, new_ranks:[0,2]}) ────────────────────► wakes  │
       │ abort_comms ──► fence flag → abort                                │
       │                 dp+ep → abort_done                                │
@@ -27,6 +27,12 @@ receive weights"). Weight transfer and resume are Phase 2.
       │                 return partial metrics       │             return
  all refs resolved → return results → exit 0
 ```
+
+The coordinator is an asyncio actor: `run_program` awaits the driver tasks,
+so `register_actors` / `get_cmd` / `wait_for_cmd` (the promotion command
+channel and per-dp_rank actor registry, formerly a separate `PromotionSignal`
+named actor) are served concurrently on the same event loop. Drivers reach it
+via the handle in `piper_metadata.coordinator`.
 
 No failure: coordinator sends `{op: shutdown}` after trainers finish; the
 standby wakes, exits; results.csv identical to a no-standby run.

--- a/docs/weight_transfer.md
+++ b/docs/weight_transfer.md
@@ -1,0 +1,67 @@
+# Weight Transfer (Phase 2)
+
+Extends standby promotion (`docs/standby_worker.md`): after the fence and
+`join_standby_group`, the standby now receives the survivor's full training
+state (params + Adam state) via NIXL RDT, and both ranks resume lockstep
+training at `last_committed + 1`. The run finishes with exit 0 instead of
+stopping cleanly.
+
+New requirements: Ray >= 2.57 and `pip install nixl`.
+
+## Architecture
+
+New steps, starting where Phase 1 ended (both peers have joined the new
+group; `join_standby_group` now also swaps it into `runtime.dp_group/ep_group`
+and lifts the fence):
+
+```
+ survivor driver              survivor actor          standby actor        standby driver
+ ───────────────              ──────────────          ─────────────        ──────────────
+                                                      prepare_standby_state (while parked):
+                                                      materialize Adam state as zeros,
+                                                      register NIXL buffers
+ make_state_ref ────────────► ray.put(state, nixl)
+ load_state([ref]) ─────────────────────────────────► set_target_for_ref(ref, own buffers)
+                              params+Adam ── RDMA ──► lands in place; sets iter counter
+ ray.get returns  = resume barrier                    wait_state_loaded returns lc+1 ─► driver
+ raise PiperResume(lc+1)
+ main loop: redo iteration lc+1  ═══ lockstep ═══     run iterations lc+1..end
+```
+
+- State = one flat list, `[p, exp_avg, exp_avg_sq, step]` per bucket param;
+  both peers build it with the same function over identical bucket layouts,
+  so `set_target_for_ref` matches by position.
+- The ref is created with `ray.put(..., _tensor_transport="nixl")` (not a
+  decorated method): Ray 2.57 only borrows nested refs created via ray.put.
+- The survivor's `ray.get` on `load_state` is the resume barrier: its live
+  tensors are not stepped until the transfer has landed.
+
+## Tests and results
+
+E2E (same command as Phase 1's promotion test):
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1,2 PIPER_FAULT=bwd:4:1 python examples/test_harness.py \
+  --test-file examples/test_qwen.py --base-schedule examples/base-schedules/dp2.json \
+  --schedule 1f1b --ranks 1 --mbs 1 --num-standby 1
+```
+
+Result (2026-08-26, 3x H200 idle, exit 0):
+
+```
+04:16:33.319  a dp_rank task failed (1/2)
+04:16:33.534  fenced ... optimizer step refused (last_committed=3)
+04:16:36.827  standby: state loaded; running iterations 4..5 as replacement
+04:16:36.827  survivor: resuming after promotion at iteration 4
+              metrics written to out/20260826_041508/results.csv
+```
+
+Fault -> resumed training ~3.5 s (transfer ~3 s, incl. one-time NIXL agent
+init). The first redone iteration additionally pays the new NCCL group's
+lazy communicator init.
+
+## Limitations
+
+- The promoted standby's iterations are not recorded in `results.csv`.
+- Recovery granularity is a whole iteration (`last_committed + 1`). No step classifications.
+- NCCL hangs not detected.

--- a/examples/base-schedules/dp2.json
+++ b/examples/base-schedules/dp2.json
@@ -1,0 +1,4 @@
+[
+  { "op": "place",     "filter": { "PP": 0 }, "devices": [0, 1] },
+  { "op": "replicate", "filter": { "PP": 0 }, "devices": [0, 1], "reduce_stream": "dp_stream" }
+]

--- a/examples/test_harness.py
+++ b/examples/test_harness.py
@@ -126,6 +126,12 @@ def main() -> None:
         default=None,
         help="Ray namespace. Defaults to the selected test module name.",
     )
+    parser.add_argument(
+        "--num-standby",
+        type=int,
+        default=0,
+        help="Number of standby DP ranks to reserve (one extra GPU bundle each).",
+    )
     args, test_args = parser.parse_known_args()
 
     if args.schedule != "custom":
@@ -241,12 +247,17 @@ def _run_test_module(
     )
     try:
         pp_outer = getattr(test_ns, "pp_outer", False)
-        pg = create_piper_placement_group(test_ns.schedule_directives_file, pp_outer=pp_outer)
+        num_standby = getattr(args, "num_standby", 0)
+        pg = create_piper_placement_group(
+            test_ns.schedule_directives_file, pp_outer=pp_outer,
+            num_standby=num_standby,
+        )
         ray.get(pg.ready(), timeout=600)
         logging.getLogger(module_name).info(placement_group_table(pg))
         coordinator = PiperProgramCoordinator.remote(
             schedule_directives_file=test_ns.schedule_directives_file,
             pp_outer=pp_outer,
+            num_standby=num_standby,
         )
         handles = coordinator.run_program.remote(test_module.main, pg, test_ns, pg)
         dp_metrics = ray.get(handles)

--- a/examples/test_qwen.py
+++ b/examples/test_qwen.py
@@ -6,7 +6,6 @@ import time
 import os
 
 from src.compile import piper_setup
-from src.coordinator import _PROMOTION_SIGNAL_ACTOR
 from src.piper import piper_exec_dag, PiperResume
 from src.schedule import load_schedule_directives
 from src.state import piper_metadata, create_logger, LOG_LEVEL
@@ -51,12 +50,12 @@ def _run_standby(dp_rank, args, loss_fn):
     args: parsed harness arguments.
     loss_fn: loss used by piper_exec_dag.
     """
-    sig = ray.get_actor(_PROMOTION_SIGNAL_ACTOR)
+    coordinator = piper_metadata.coordinator
     actor = piper_metadata.actors[0] # pp_degree == 1
     ray.get(actor.prepare_standby_state.remote())
     logger.info(f"standby dp_rank {dp_rank}: initialized and parked; "
                 "waiting for promotion or shutdown")
-    cmd = ray.get(sig.wait_for_cmd.remote())
+    cmd = ray.get(coordinator.wait_for_cmd.remote())
     if cmd.get("op") == "promote":
         ray.get(
             actor.join_standby_group.remote(cmd["new_ranks"]),

--- a/examples/test_qwen.py
+++ b/examples/test_qwen.py
@@ -6,7 +6,8 @@ import time
 import os
 
 from src.compile import piper_setup
-from src.piper import piper_exec_dag
+from src.coordinator import _PROMOTION_SIGNAL_ACTOR
+from src.piper import piper_exec_dag, PiperFencedError
 from src.schedule import load_schedule_directives
 from src.state import piper_metadata, create_logger, LOG_LEVEL
 
@@ -40,6 +41,29 @@ def _raw_metrics(args, iter_times, peak_memory_stats):
             int(rank): int(max_alloc) for rank, max_alloc in peak_memory_stats
         },
     }
+
+
+def _run_standby(dp_rank):
+    """Park until the coordinator promotes this standby or shuts it down.
+
+    dp_rank: this standby's dp_rank (>= dp_degree).
+    """
+    sig = ray.get_actor(_PROMOTION_SIGNAL_ACTOR)
+    logger.info(f"standby dp_rank {dp_rank}: initialized and parked; "
+                "waiting for promotion or shutdown")
+    cmd = ray.get(sig.wait_for_cmd.remote())
+    if cmd.get("op") == "promote":
+        res = ray.get(
+            piper_metadata.actors[0].join_standby_group.remote(cmd["new_ranks"]),
+            timeout=180,
+        )
+        logger.info(f"standby dp_rank {dp_rank}: joined NCCL group "
+                    f"{cmd['new_ranks']} (sanity allreduce={res})")
+        # Phase 1 stops here; Phase 2 receives weights and resumes training.
+        print("ready to receive weights", flush=True)
+    else:
+        logger.info(f"standby dp_rank {dp_rank}: shutdown received; exiting")
+    return None
 
 
 def main(args, pg):
@@ -84,6 +108,12 @@ def main(args, pg):
 
     actors = piper_metadata.actors
 
+    # Standby ranks never train: park until promoted or shut down.
+    dp_rank = int(os.environ["PIPER_DP_RANK"])
+    dp_degree = int(os.environ["PIPER_DP_DEGREE"])
+    if dp_rank >= dp_degree:
+        return _run_standby(dp_rank)
+
     # No step_timeout during warmup; afterward 5x the last warmup step
     # (~steady step time), floored at 5s.
     logger.info(f"Running {args.warmup} warmup iterations")
@@ -101,13 +131,21 @@ def main(args, pg):
     logger.info(f"Running {args.iters} timed iterations")
     ray.get([actor.reset_peak_memory.remote() for actor in actors.values()])
     iter_times = []
-    for _ in range(args.iters):
-        start = time.perf_counter()
-        piper_exec_dag(loss_fn, log_stats=True, step_timeout=step_timeout)
-        end = time.perf_counter()
-        iter_times.append(end - start)
-        if args.iteration_sleep > 0:
-            time.sleep(args.iteration_sleep)
+    fenced = False
+    try:
+        for _ in range(args.iters):
+            start = time.perf_counter()
+            piper_exec_dag(loss_fn, log_stats=True, step_timeout=step_timeout)
+            end = time.perf_counter()
+            iter_times.append(end - start)
+            if args.iteration_sleep > 0:
+                time.sleep(args.iteration_sleep)
+    except PiperFencedError as exc:
+        # Promotion fenced this rank mid-step; Phase 1 ends the run cleanly
+        # with the iterations completed so far.
+        fenced = True
+        logger.info(f"run fenced during promotion after "
+                    f"{len(iter_times)} timed iterations: {exc}")
 
     peak_memory_stats = ray.get(
         [actor.get_and_reset_peak_memory_stats.remote() for actor in actors.values()]
@@ -115,7 +153,7 @@ def main(args, pg):
 
     metrics = _raw_metrics(args, iter_times, peak_memory_stats)
 
-    if args.pytorch_profiler:
+    if args.pytorch_profiler and not fenced:
         profile_dir = getattr(args, "profile_dir", "") or os.path.join(
             "out", "pytorch_profiles"
         )

--- a/examples/test_qwen.py
+++ b/examples/test_qwen.py
@@ -7,7 +7,7 @@ import os
 
 from src.compile import piper_setup
 from src.coordinator import _PROMOTION_SIGNAL_ACTOR
-from src.piper import piper_exec_dag, PiperFencedError
+from src.piper import piper_exec_dag, PiperResume
 from src.schedule import load_schedule_directives
 from src.state import piper_metadata, create_logger, LOG_LEVEL
 
@@ -43,24 +43,34 @@ def _raw_metrics(args, iter_times, peak_memory_stats):
     }
 
 
-def _run_standby(dp_rank):
-    """Park until the coordinator promotes this standby or shuts it down.
+def _run_standby(dp_rank, args, loss_fn):
+    """Park until promoted or shut down; on promotion, receive the survivor's
+    state and train the remaining iterations as the failed rank's replacement.
 
     dp_rank: this standby's dp_rank (>= dp_degree).
+    args: parsed harness arguments.
+    loss_fn: loss used by piper_exec_dag.
     """
     sig = ray.get_actor(_PROMOTION_SIGNAL_ACTOR)
+    actor = piper_metadata.actors[0] # pp_degree == 1
+    ray.get(actor.prepare_standby_state.remote())
     logger.info(f"standby dp_rank {dp_rank}: initialized and parked; "
                 "waiting for promotion or shutdown")
     cmd = ray.get(sig.wait_for_cmd.remote())
     if cmd.get("op") == "promote":
-        res = ray.get(
-            piper_metadata.actors[0].join_standby_group.remote(cmd["new_ranks"]),
+        ray.get(
+            actor.join_standby_group.remote(cmd["new_ranks"]),
             timeout=180,
         )
         logger.info(f"standby dp_rank {dp_rank}: joined NCCL group "
-                    f"{cmd['new_ranks']} (sanity allreduce={res})")
-        # Phase 1 stops here; Phase 2 receives weights and resumes training.
-        print("ready to receive weights", flush=True)
+                    f"{cmd['new_ranks']}")
+        next_iter = ray.get(actor.wait_state_loaded.remote(), timeout=600)
+        total = args.warmup + args.iters
+        logger.info(f"standby dp_rank {dp_rank}: state loaded; running "
+                    f"iterations {next_iter}..{total - 1} as replacement")
+        for _ in range(total - next_iter):
+            piper_exec_dag(loss_fn)
+        logger.info(f"standby dp_rank {dp_rank}: replacement training finished")
     else:
         logger.info(f"standby dp_rank {dp_rank}: shutdown received; exiting")
     return None
@@ -112,40 +122,50 @@ def main(args, pg):
     dp_rank = int(os.environ["PIPER_DP_RANK"])
     dp_degree = int(os.environ["PIPER_DP_DEGREE"])
     if dp_rank >= dp_degree:
-        return _run_standby(dp_rank)
+        return _run_standby(dp_rank, args, loss_fn)
 
     # No step_timeout during warmup; afterward 5x the last warmup step
     # (~steady step time), floored at 5s.
     logger.info(f"Running {args.warmup} warmup iterations")
     last_warmup_time = None
-    for _ in range(args.warmup):
-        t0 = time.perf_counter()
-        piper_exec_dag(loss_fn)
-        last_warmup_time = time.perf_counter() - t0
-        if args.iteration_sleep > 0:
-            time.sleep(args.iteration_sleep)
-    step_timeout = (
-        max(5.0, 5 * last_warmup_time) if last_warmup_time is not None else None
-    )
-
-    logger.info(f"Running {args.iters} timed iterations")
-    ray.get([actor.reset_peak_memory.remote() for actor in actors.values()])
+    step_timeout = None
     iter_times = []
-    fenced = False
-    try:
-        for _ in range(args.iters):
-            start = time.perf_counter()
-            piper_exec_dag(loss_fn, log_stats=True, step_timeout=step_timeout)
-            end = time.perf_counter()
-            iter_times.append(end - start)
-            if args.iteration_sleep > 0:
-                time.sleep(args.iteration_sleep)
-    except PiperFencedError as exc:
-        # Promotion fenced this rank mid-step; Phase 1 ends the run cleanly
-        # with the iterations completed so far.
-        fenced = True
-        logger.info(f"run fenced during promotion after "
-                    f"{len(iter_times)} timed iterations: {exc}")
+    total = args.warmup + args.iters
+    it = 0
+    while it < total:
+        try:
+            if it < args.warmup:
+                t0 = time.perf_counter()
+                piper_exec_dag(loss_fn)
+                last_warmup_time = time.perf_counter() - t0
+                if args.iteration_sleep > 0:
+                    time.sleep(args.iteration_sleep)
+                it += 1
+                if it == args.warmup:
+                    step_timeout = (
+                        max(5.0, 5 * last_warmup_time)
+                        if last_warmup_time is not None
+                        else None
+                    )
+                    logger.info(f"Running {args.iters} timed iterations")
+                    ray.get([
+                        actor.reset_peak_memory.remote()
+                        for actor in actors.values()
+                    ])
+            else:
+                start = time.perf_counter()
+                piper_exec_dag(loss_fn, log_stats=True, step_timeout=step_timeout)
+                end = time.perf_counter()
+                iter_times.append(end - start)
+                if args.iteration_sleep > 0:
+                    time.sleep(args.iteration_sleep)
+                it += 1
+        except PiperResume as exc:
+            # Promotion recovery replaced the failed peer; redo the
+            # interrupted iteration in lockstep with the promoted standby.
+            logger.info(f"resuming after promotion at iteration "
+                        f"{exc.next_iter} (was at {it})")
+            it = exc.next_iter
 
     peak_memory_stats = ray.get(
         [actor.get_and_reset_peak_memory_stats.remote() for actor in actors.values()]
@@ -153,7 +173,7 @@ def main(args, pg):
 
     metrics = _raw_metrics(args, iter_times, peak_memory_stats)
 
-    if args.pytorch_profiler and not fenced:
+    if args.pytorch_profiler:
         profile_dir = getattr(args, "profile_dir", "") or os.path.join(
             "out", "pytorch_profiles"
         )

--- a/examples/test_qwen.py
+++ b/examples/test_qwen.py
@@ -84,18 +84,26 @@ def main(args, pg):
 
     actors = piper_metadata.actors
 
+    # No step_timeout during warmup; afterward 5x the last warmup step
+    # (~steady step time), floored at 5s.
     logger.info(f"Running {args.warmup} warmup iterations")
+    last_warmup_time = None
     for _ in range(args.warmup):
+        t0 = time.perf_counter()
         piper_exec_dag(loss_fn)
+        last_warmup_time = time.perf_counter() - t0
         if args.iteration_sleep > 0:
             time.sleep(args.iteration_sleep)
+    step_timeout = (
+        max(5.0, 5 * last_warmup_time) if last_warmup_time is not None else None
+    )
 
     logger.info(f"Running {args.iters} timed iterations")
     ray.get([actor.reset_peak_memory.remote() for actor in actors.values()])
     iter_times = []
     for _ in range(args.iters):
         start = time.perf_counter()
-        piper_exec_dag(loss_fn, log_stats=True)
+        piper_exec_dag(loss_fn, log_stats=True, step_timeout=step_timeout)
         end = time.perf_counter()
         iter_times.append(end - start)
         if args.iteration_sleep > 0:
@@ -114,7 +122,7 @@ def main(args, pg):
         logger.info(f"Running {args.pytorch_profiler_iters} PyTorch-profiled iterations")
         ray.get([actor.start_pytorch_profiler.remote() for actor in actors.values()])
         for _ in range(args.pytorch_profiler_iters):
-            piper_exec_dag(loss_fn)
+            piper_exec_dag(loss_fn, step_timeout=step_timeout)
             if args.iteration_sleep > 0:
                 time.sleep(args.iteration_sleep)
         ray.get([

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 torchtitan
 numpy
 torch==2.10.0
-ray==2.44.1
+ray==2.57.0
+nixl
 click<8.1
 cupy-cuda12x
 bitsandbytes

--- a/src/actor.py
+++ b/src/actor.py
@@ -1,4 +1,5 @@
 import ray
+import threading
 import torch
 import os
 import re
@@ -69,6 +70,12 @@ def _create_actors(
                 # "NCCL_P2P_DISABLE": "1",
                 # "NCCL_DEBUG": "INFO",
                 **({"TMPDIR": temp_dir} if (profile and temp_dir) else {}),
+                # Actors don't inherit the driver's os.environ.
+                "PIPER_NUM_STANDBY": os.environ.get("PIPER_NUM_STANDBY", "0"),
+                # Watchdog auto-handling reacts to our intentional abort by
+                # aborting every comm (see _abort_process_group docs).
+                **({"TORCH_NCCL_ASYNC_ERROR_HANDLING": "0"}
+                   if int(os.environ.get("PIPER_NUM_STANDBY", "0")) > 0 else {}),
             }
         }
         # When pp_outer=True, one bundle corresponds to one pipeline stage and
@@ -78,6 +85,9 @@ def _create_actors(
         bundle_index = pp_rank if pp_outer else dp_rank
         actor = PiperActor.options(
             num_gpus=0.6,
+            # Threaded actor: control methods (abort_comms, get_last_committed,
+            # join_standby_group) must run while run_dag blocks the main call.
+            max_concurrency=2,
             runtime_env={**nsight_env, **nccl_env},
             scheduling_strategy=PlacementGroupSchedulingStrategy(
                 placement_group=pg,
@@ -159,6 +169,14 @@ class PiperActor:
             self.compute,
             self.logger,
         )
+        # Standby mode: UPD must CPU-sync all-reduces and honor the fence flag
+        # (an aborted collective otherwise commits garbage gradients).
+        self.dag_executor._cpu_sync_allreduce = (
+            int(os.environ.get("PIPER_NUM_STANDBY", "0")) > 0
+        )
+        # Set when abort_comms has fully finished; join_standby_group must not
+        # build a new comm while an abort is still in flight in this process.
+        self._abort_done = threading.Event()
 
         # Non-trainable constant tensor attributes (e.g. freqs_cis, mask) pushed
         # from the coordinator before compilation so _load_stage can fill them in
@@ -265,7 +283,10 @@ class PiperActor:
             self.logger.debug(f"Actor {self.runtime.global_rank} joined process groups")
 
     def _join_dp_process_group(self):
-        num_dp_groups = self.runtime.world_size // self.runtime.dp_degree
+        # Standby ranks execute every collective new_group call (required by
+        # default-mode new_group) but are members of no dp/ep group.
+        n_trainers = self.runtime.dp_degree * self.runtime.pp_degree
+        num_dp_groups = n_trainers // self.runtime.dp_degree
         for dp_group_id in range(num_dp_groups):
             group_ranks = [
                 (dp_group_id + num_dp_groups * i) for i in range(self.runtime.dp_degree)
@@ -275,12 +296,13 @@ class PiperActor:
             # the same internal NCCL proxy stream, which prevents true overlap.
             process_group = dist.new_group(ranks=group_ranks, backend="nccl")
             ep_process_group = dist.new_group(ranks=group_ranks, backend="nccl")
-            if self.runtime.global_rank % num_dp_groups == dp_group_id:
+            if self.runtime.global_rank in group_ranks:
                 self.runtime.dp_group = process_group
                 self.runtime.ep_group = ep_process_group
 
     def _join_pp_process_group(self):
-        num_pp_groups = self.runtime.world_size // self.runtime.pp_degree
+        n_trainers = self.runtime.dp_degree * self.runtime.pp_degree
+        num_pp_groups = n_trainers // self.runtime.pp_degree
 
         for pp_group_id in range(num_pp_groups):
             group_ranks = [
@@ -292,6 +314,62 @@ class PiperActor:
             if self.runtime.global_rank in group_ranks:
                 self.runtime.pp_lo_hi = lo_hi_group
                 self.runtime.pp_hi_lo = hi_lo_group
+
+    def abort_comms(self):
+        """Abort this actor's dp/ep NCCL communicators (fencing during promotion)."""
+        from torch.distributed.distributed_c10d import _abort_process_group
+
+        # The fence flag must be visible BEFORE the abort releases any kernel,
+        # so the executor refuses the poisoned iteration's optimizer step.
+        self.dag_executor._fenced = True
+        aborted = []
+        if self.runtime.dp_group is not None:
+            _abort_process_group(self.runtime.dp_group)
+            aborted.append("dp_group")
+        if self.runtime.ep_group is not None:
+            _abort_process_group(self.runtime.ep_group)
+            aborted.append("ep_group")
+        self.logger.info(f"abort_comms: aborted {aborted}")
+        self._abort_done.set()
+        return aborted
+
+    def join_standby_group(self, new_ranks):
+        """Create the survivor+standby dp/ep groups and verify with an all-reduce.
+
+        new_ranks: sorted global ranks of the members; only members call this.
+        """
+        new_ranks = list(new_ranks)
+        if self.dag_executor._fenced:
+            # Building a fresh NCCL comm while an abort is in flight in this
+            # process deadlocks; wait for abort_comms to finish.
+            if not self._abort_done.wait(timeout=120):
+                raise RuntimeError("abort_comms did not finish within 120s")
+            torch.cuda.synchronize()
+        self.logger.info(f"join_standby_group: creating groups ranks={new_ranks}")
+        new_dp = dist.new_group(
+            ranks=new_ranks, backend="nccl", use_local_synchronization=True
+        )
+        new_ep = dist.new_group(
+            ranks=new_ranks, backend="nccl", use_local_synchronization=True
+        )
+        self.logger.info("join_standby_group: groups created; running sanity all_reduce")
+        # Force eager communicator construction and prove the group works:
+        # each member contributes 1, so the result equals len(new_ranks).
+        probe = torch.ones(1, device=self.runtime.device)
+        dist.all_reduce(probe, group=new_dp)
+        torch.cuda.synchronize()
+        # Phase 2 will swap these into runtime.dp_group/ep_group at promotion.
+        self.runtime.standby_dp_group = new_dp
+        self.runtime.standby_ep_group = new_ep
+        val = float(probe.item())
+        self.logger.info(
+            f"join_standby_group: ranks={new_ranks} sanity_allreduce={val}"
+        )
+        return val
+
+    def get_last_committed(self):
+        """Last iteration whose optimizer update fully committed (-1 if none)."""
+        return getattr(self.dag_executor, "_last_committed", -1)
 
     def _derive_dag_bucket_modes(self, training_dag: Any) -> None:
         self.stages.param_sharded_ubids = set()

--- a/src/actor.py
+++ b/src/actor.py
@@ -85,9 +85,11 @@ def _create_actors(
         bundle_index = pp_rank if pp_outer else dp_rank
         actor = PiperActor.options(
             num_gpus=0.6,
-            # Threaded actor: control methods (abort_comms, get_last_committed,
-            # join_standby_group) must run while run_dag blocks the main call.
+            # Threaded actor:
+            # - Survivor: abort_comms must run while run_dag is blocked.
+            # - Standby: load_state must run while wait_state_loaded is blocked.
             max_concurrency=2,
+            enable_tensor_transport=True,
             runtime_env={**nsight_env, **nccl_env},
             scheduling_strategy=PlacementGroupSchedulingStrategy(
                 placement_group=pg,
@@ -177,6 +179,9 @@ class PiperActor:
         # Set when abort_comms has fully finished; join_standby_group must not
         # build a new comm while an abort is still in flight in this process.
         self._abort_done = threading.Event()
+        self._state_loaded = threading.Event()
+        self._resume_iter = None
+        self._promotion_tensors = None
 
         # Non-trainable constant tensor attributes (e.g. freqs_cis, mask) pushed
         # from the coordinator before compilation so _load_stage can fill them in
@@ -334,7 +339,8 @@ class PiperActor:
         return aborted
 
     def join_standby_group(self, new_ranks):
-        """Create the survivor+standby dp/ep groups and verify with an all-reduce.
+        """Create the survivor+standby dp/ep groups, make them the active
+        training groups, and lift the fence.
 
         new_ranks: sorted global ranks of the members; only members call this.
         """
@@ -352,24 +358,98 @@ class PiperActor:
         new_ep = dist.new_group(
             ranks=new_ranks, backend="nccl", use_local_synchronization=True
         )
-        self.logger.info("join_standby_group: groups created; running sanity all_reduce")
-        # Force eager communicator construction and prove the group works:
-        # each member contributes 1, so the result equals len(new_ranks).
-        probe = torch.ones(1, device=self.runtime.device)
-        dist.all_reduce(probe, group=new_dp)
-        torch.cuda.synchronize()
-        # Phase 2 will swap these into runtime.dp_group/ep_group at promotion.
-        self.runtime.standby_dp_group = new_dp
-        self.runtime.standby_ep_group = new_ep
-        val = float(probe.item())
-        self.logger.info(
-            f"join_standby_group: ranks={new_ranks} sanity_allreduce={val}"
-        )
-        return val
+        # Communicator construction is lazy: the first collective of the
+        # resumed training initializes it.
+        self.runtime.dp_group = new_dp
+        self.runtime.ep_group = new_ep
+        self.dag_executor._fenced = False
+        self.logger.info(f"join_standby_group: joined ranks={new_ranks}")
+        return new_ranks
 
     def get_last_committed(self):
         """Last iteration whose optimizer update fully committed (-1 if none)."""
         return getattr(self.dag_executor, "_last_committed", -1)
+
+    def _promotion_state_tensors(self):
+        """Flat list of param + Adam state tensors transferred at promotion.
+
+        Survivor: the tensors to send. Standby: the buffers to receive
+        into; its missing Adam state is created as zeros.
+        """
+        if self._promotion_tensors is not None:
+            return self._promotion_tensors
+        if self.stages.zero_managed_ubids:
+            raise NotImplementedError(
+                "standby weight transfer supports pure DP only"
+            )
+        tensors = []
+        for _, bucket in self.stages.buckets.items():
+            opt = bucket.optimizer
+            if opt is None:
+                continue
+            for p in bucket.trainable_params():
+                st = opt.state.get(p)
+                if st is None:
+                    # Fused Adam creates state lazily on first step; the
+                    # standby never steps, so materialize matching zeros.
+                    st = {
+                        "step": torch.zeros(
+                            (), dtype=torch.float32, device=p.device
+                        ),
+                        "exp_avg": torch.zeros_like(p),
+                        "exp_avg_sq": torch.zeros_like(p),
+                    }
+                    opt.state[p] = st
+                tensors.extend(
+                    [p.detach(), st["exp_avg"], st["exp_avg_sq"], st["step"]]
+                ) # Flat because set_target_for_ref matches by position.
+        self._promotion_tensors = tensors
+        return tensors
+
+    def prepare_standby_state(self):
+        """Materialize optimizer state and pre-register NIXL buffers while parked."""
+        tensors = self._promotion_state_tensors()
+        try:
+            for t in tensors:
+                ray.experimental.register_nixl_memory(t)
+        except Exception:
+            self.logger.exception(
+                "register_nixl_memory failed; registration will happen at transfer time"
+            )
+        return len(tensors)
+
+    def make_state_ref(self):
+        """Publish params + optimizer state + resume iteration via NIXL RDT.
+
+        Returns a ray.put-created ObjectRef (borrowable, see ray#59644).
+        """
+        state = {
+            "next_iter": self.dag_executor._last_committed + 1,
+            "tensors": self._promotion_state_tensors(),
+        }
+        return ray.put(state, _tensor_transport="nixl")
+
+    def load_state(self, refs):
+        """Receive the survivor's state directly into this actor's buffers.
+
+        refs: single-element list holding the state ObjectRef.
+        """
+        ref, = refs
+        targets = self._promotion_state_tensors()
+        ray.experimental.set_target_for_ref(ref, targets)
+        state = ray.get(ref)
+        next_iter = int(state["next_iter"])
+        self._iter_counter = next_iter
+        self.dag_executor._last_committed = next_iter - 1
+        self._resume_iter = next_iter
+        self._state_loaded.set()
+        return next_iter
+
+    def wait_state_loaded(self):
+        """Block until load_state has landed; returns the iteration to resume at."""
+        if not self._state_loaded.wait(timeout=600):
+            raise RuntimeError("standby state was not loaded within 600s")
+        return self._resume_iter
 
     def _derive_dag_bucket_modes(self, training_dag: Any) -> None:
         self.stages.param_sharded_ubids = set()

--- a/src/actor.py
+++ b/src/actor.py
@@ -735,6 +735,8 @@ class PiperActor:
         # Mark the entire iteration boundary for the NVTX timeline.
         iter_idx = getattr(self, "_iter_counter", 0)
         self._iter_counter = iter_idx + 1
+        # Debug-only: expose the iteration counter for E2E fault injection.
+        self.dag_executor._iter_count = iter_idx
         self._nvtx_push(f"iter_{iter_idx}_rank_{self.runtime.global_rank}")
         self.dag_executor.run(
             self.dag,

--- a/src/compile.py
+++ b/src/compile.py
@@ -250,6 +250,22 @@ def piper_setup(
             for actor in piper_metadata.actors.values()
         ])
 
+    # Standby support: register this dp_rank's actor handles so the
+    # coordinator can fence survivors (abort_comms) during promotion.
+    if int(os.environ.get("PIPER_NUM_STANDBY", "0")) > 0:
+        from .coordinator import _PROMOTION_SIGNAL_ACTOR
+
+        try:
+            sig = ray.get_actor(_PROMOTION_SIGNAL_ACTOR)
+            ray.get(sig.register_actors.remote(
+                dp_rank, list(piper_metadata.actors.values())
+            ))
+        except ValueError:
+            logger.warning(
+                "PIPER_NUM_STANDBY set but promotion-signal actor not found; "
+                "fencing will be unavailable"
+            )
+
     if dp_rank == 0:
         # --- dp_rank=0: run torch.compile, build DAGs, publish compiled data ---
 

--- a/src/compile.py
+++ b/src/compile.py
@@ -250,8 +250,6 @@ def piper_setup(
             for actor in piper_metadata.actors.values()
         ])
 
-    # Standby support: register this dp_rank's actor handles so the
-    # coordinator can fence survivors (abort_comms) during promotion.
     if int(os.environ.get("PIPER_NUM_STANDBY", "0")) > 0:
         from .coordinator import _PROMOTION_SIGNAL_ACTOR
 

--- a/src/compile.py
+++ b/src/compile.py
@@ -251,18 +251,9 @@ def piper_setup(
         ])
 
     if int(os.environ.get("PIPER_NUM_STANDBY", "0")) > 0:
-        from .coordinator import _PROMOTION_SIGNAL_ACTOR
-
-        try:
-            sig = ray.get_actor(_PROMOTION_SIGNAL_ACTOR)
-            ray.get(sig.register_actors.remote(
-                dp_rank, list(piper_metadata.actors.values())
-            ))
-        except ValueError:
-            logger.warning(
-                "PIPER_NUM_STANDBY set but promotion-signal actor not found; "
-                "fencing will be unavailable"
-            )
+        ray.get(piper_metadata.coordinator.register_actors.remote(
+            dp_rank, list(piper_metadata.actors.values())
+        ))
 
     if dp_rank == 0:
         # --- dp_rank=0: run torch.compile, build DAGs, publish compiled data ---

--- a/src/coordinator.py
+++ b/src/coordinator.py
@@ -40,9 +40,6 @@ class PiperProgramCoordinator:
     """Central actor that coordinates all the DP replicas of a single
     pipeline: spawns and supervises the dp_rank driver tasks, and serves as
     the promotion command channel and per-dp_rank actor registry.
-
-    cmd: None until set; then {"op": "promote", "failed": int, "source": int,
-    "new_ranks": [int, int]} or {"op": "shutdown"}.
     """
 
     def __init__(
@@ -174,10 +171,8 @@ class PiperProgramCoordinator:
             try:
                 res = task.result()
                 if task in standby_tasks:
-                    # Case 1 (no failure): standby was shut down, returns None,
-                    # no metrics to record — drop is correct.
-                    # TODO(phase-2), case 2 (promoted): the standby trained as a
-                    # replacement and returns real metrics; append to results.
+                    # Standby returns None in both cases: shut down (nothing to record) or
+                    # promoted (TODO: return the replacement's metrics and append to results).
                     logger.info(f"standby dp_rank {rank} task finished")
                 else:
                     results.append(res)

--- a/src/coordinator.py
+++ b/src/coordinator.py
@@ -1,3 +1,4 @@
+import asyncio
 import ray
 from typing import Callable
 import os
@@ -8,8 +9,38 @@ from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from .state import create_logger, LOG_LEVEL
 from .schedule import load_schedule_info
 
-# No standby worker exists yet: fail fast on the first dp_rank failure.
-STANDBY_ENABLED = os.environ.get("PIPER_STANDBY_ENABLED", "0") == "1"
+_PROMOTION_SIGNAL_ACTOR = "piper_promotion_signal"
+
+
+@ray.remote(num_cpus=0)
+class PromotionSignal:
+    """Named actor: promotion command channel + per-dp_rank actor registry.
+
+    cmd: None until set; then {"op": "promote", "failed": int, "source": int,
+    "new_ranks": [int, int]} or {"op": "shutdown"}.
+    """
+
+    def __init__(self):
+        self._cmd = None
+        self._event = asyncio.Event()
+        self._actors = {}
+
+    def register_actors(self, dp_rank, handles):
+        self._actors[dp_rank] = handles
+
+    def get_actors(self, dp_rank):
+        return self._actors.get(dp_rank)
+
+    def set(self, cmd):
+        self._cmd = cmd
+        self._event.set()
+
+    def get(self):
+        return self._cmd
+
+    async def wait_for_cmd(self):
+        await self._event.wait()
+        return self._cmd
 
 
 # Coordinator needs GPUs when using profiling to infer stage boundaries
@@ -17,7 +48,7 @@ STANDBY_ENABLED = os.environ.get("PIPER_STANDBY_ENABLED", "0") == "1"
 
 # Use manual stage annotations- more stable
 @ray.remote(num_gpus=0.1)
-def run_dp_rank(dp_rank, dp_degree, pp_degree, world_size, training_func: Callable, *args, **kwargs):
+def run_dp_rank(dp_rank, dp_degree, pp_degree, world_size, training_func: Callable, *args, num_standby=0, **kwargs):
     logger = create_logger("coordinator", LOG_LEVEL)
     logger.debug(f"Running DP rank {dp_rank+1} of {dp_degree}")
 
@@ -25,6 +56,7 @@ def run_dp_rank(dp_rank, dp_degree, pp_degree, world_size, training_func: Callab
     os.environ["PIPER_DP_DEGREE"] = str(dp_degree)
     os.environ["PIPER_PP_DEGREE"] = str(pp_degree)
     os.environ["PIPER_WORLD_SIZE"] = str(world_size)
+    os.environ["PIPER_NUM_STANDBY"] = str(num_standby)
     os.environ["TORCH_LOGS"] = "+graph_breaks"
     return training_func(*args, **kwargs)
 
@@ -37,13 +69,21 @@ class PiperProgramCoordinator:
         self,
         pp_outer: bool = False,
         schedule_directives_file: str | None = None,
+        num_standby: int = 0,
     ):
         if schedule_directives_file is None:
             raise ValueError("PiperProgramCoordinator requires schedule_directives_file")
         info = load_schedule_info(schedule_directives_file)
         self.dp_degree = info["dp_degree"]
         self.pp_degree = info["pp_degree"]
-        self.world_size = self.dp_degree * self.pp_degree
+        self.num_standby = int(num_standby)
+        if self.num_standby > 0 and (self.pp_degree > 1 or pp_outer):
+            raise NotImplementedError(
+                "standby ranks are only supported with pp_degree == 1 and pp_inner placement"
+            )
+        # Standby ranks are enrolled in the NCCL world but excluded from all
+        # dp/ep training groups.
+        self.world_size = self.dp_degree * self.pp_degree + self.num_standby
         # pp_outer=True means one PP stage per node (placement bundles keyed by
         # pp_rank). In that mode DP drivers are spread across the pp bundles.
         self.pp_outer = pp_outer
@@ -68,6 +108,18 @@ class PiperProgramCoordinator:
             logger.exception("Failed to kill stale Ray actor named %s", _COMPILED_DATA_ACTOR)
             raise
 
+        sig = None
+        if self.num_standby > 0:
+            try:
+                ray.kill(ray.get_actor(_PROMOTION_SIGNAL_ACTOR))
+            except ValueError:
+                pass
+            sig = PromotionSignal.options(
+                name=_PROMOTION_SIGNAL_ACTOR, num_cpus=0
+            ).remote()
+            ray.get(sig.get.remote())  # ensure the name is resolvable before drivers start
+
+        n_ranks = self.dp_degree + self.num_standby
         refs = [
             run_dp_rank.options(
                 scheduling_strategy=PlacementGroupSchedulingStrategy(
@@ -83,46 +135,120 @@ class PiperProgramCoordinator:
                 self.world_size,
                 training_func,
                 *args,
+                num_standby=self.num_standby,
                 **kwargs,
             )
-            for dp_rank in range(self.dp_degree)
+            for dp_rank in range(n_ranks)
         ]
+        ref_to_rank = {ref: dp_rank for dp_rank, ref in enumerate(refs)}
+        trainer_pending = set(refs[: self.dp_degree])
+        standby_refs = set(refs[self.dp_degree:])
 
-        # React to whichever dp_rank task finishes or fails first.
+        # React to whichever dp_rank task finishes or fails first. Standby
+        # tasks are excluded from failure accounting.
         pending = list(refs)
         results = []
         failures = 0
+        promoted = False
+        shutdown_sent = False
+        alive_standby = list(range(self.dp_degree, n_ranks))
         while pending:
+            if (
+                sig is not None
+                and not promoted
+                and not shutdown_sent
+                and not trainer_pending
+            ):
+                # All trainer tasks resolved without promotion: release the
+                # parked standby so the job can terminate.
+                logger.info("all trainer tasks resolved; sending shutdown to standby")
+                ray.get(sig.set.remote({"op": "shutdown"}))
+                shutdown_sent = True
             done, pending = ray.wait(pending, num_returns=1)
+            rank = ref_to_rank[done[0]]
+            trainer_pending.discard(done[0])
             try:
-                results.append(ray.get(done[0]))
+                res = ray.get(done[0])
+                if done[0] in standby_refs:
+                    # Case 1 (no failure): standby was shut down, returns None,
+                    # no metrics to record — drop is correct.
+                    # TODO(phase-2), case 2 (promoted): the standby trained as a
+                    # replacement and returns real metrics; append to results.
+                    logger.info(f"standby dp_rank {rank} task finished")
+                else:
+                    results.append(res)
             except Exception:
+                if done[0] in standby_refs:
+                    logger.exception(
+                        f"standby dp_rank {rank} task failed; failover disabled"
+                    )
+                    if rank in alive_standby:
+                        alive_standby.remove(rank)
+                    continue
                 failures += 1
                 logger.exception(
                     f"a dp_rank task failed ({failures}/{self.dp_degree})"
                 )
-                if not STANDBY_ENABLED:
-                    # M1: fail fast on first failure (see STANDBY_ENABLED above).
-                    raise
-                if failures == self.dp_degree:
-                    # Everyone is down — nothing left to wait for.
-                    raise
+                if (
+                    sig is not None
+                    and alive_standby
+                    and not promoted
+                    and failures < self.dp_degree # at least one trainer survives
+                ):
+                    promoted = True
+                    self._promote(sig, logger, failed_rank=rank,
+                                  standby_rank=alive_standby[0])
+                    continue
+                # No standby available for this failure: fail fast.
+                raise
         return results
 
+    def _promote(self, sig, logger, failed_rank: int, standby_rank: int):
+        """Promote a standby to replace a failed trainer rank.
 
-def create_piper_placement_group(schedule_directives_file: str, pp_outer: bool = False):
+        failed_rank: dp_rank whose task failed.
+        standby_rank: dp_rank of the standby taking over.
+        """
+        survivors = [
+            r for r in range(self.dp_degree) if r != failed_rank
+        ]
+        source = survivors[0]
+        # pp_degree == 1 (enforced in __init__), so global rank == dp_rank.
+        new_ranks = sorted([source, standby_rank])
+        cmd = {
+            "op": "promote",
+            "failed": failed_rank,
+            "source": source,
+            "new_ranks": new_ranks,
+        }
+        logger.info(f"promoting standby {standby_rank} for failed rank {failed_rank}: {cmd}")
+        # Order matters: the signal must be readable BEFORE any abort lands,
+        # so fenced drivers can distinguish the abort from a genuine failure.
+        ray.get(sig.set.remote(cmd))
+        for rank in survivors:
+            handles = ray.get(sig.get_actors.remote(rank))
+            for handle in handles:
+                ray.get(handle.abort_comms.remote(), timeout=60)
+
+
+def create_piper_placement_group(
+    schedule_directives_file: str, pp_outer: bool = False, num_standby: int = 0
+):
     info = load_schedule_info(schedule_directives_file)
     pp_degree = info["pp_degree"]
     dp_degree = info["dp_degree"]
 
     if pp_outer:
+        if num_standby > 0:
+            raise NotImplementedError("standby ranks require pp_inner placement")
         drivers_per_bundle = (dp_degree + pp_degree - 1) // pp_degree
         return placement_group(
             [{"CPU": dp_degree + drivers_per_bundle, "GPU": dp_degree}] * pp_degree,
             strategy="STRICT_SPREAD",
         )
 
+    # One extra bundle per standby rank: its GPU is reserved up front.
     return placement_group(
-        [{"CPU": pp_degree, "GPU": pp_degree}] * dp_degree,
+        [{"CPU": pp_degree, "GPU": pp_degree}] * (dp_degree + num_standby),
         strategy="SPREAD",
     )

--- a/src/coordinator.py
+++ b/src/coordinator.py
@@ -7,40 +7,8 @@ from ray.util.placement_group import placement_group
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 from .state import create_logger, LOG_LEVEL
+from . import state as piper_state
 from .schedule import load_schedule_info
-
-_PROMOTION_SIGNAL_ACTOR = "piper_promotion_signal"
-
-
-@ray.remote(num_cpus=0)
-class PromotionSignal:
-    """Named actor: promotion command channel + per-dp_rank actor registry.
-
-    cmd: None until set; then {"op": "promote", "failed": int, "source": int,
-    "new_ranks": [int, int]} or {"op": "shutdown"}.
-    """
-
-    def __init__(self):
-        self._cmd = None
-        self._event = asyncio.Event()
-        self._actors = {}
-
-    def register_actors(self, dp_rank, handles):
-        self._actors[dp_rank] = handles
-
-    def get_actors(self, dp_rank):
-        return self._actors.get(dp_rank)
-
-    def set(self, cmd):
-        self._cmd = cmd
-        self._event.set()
-
-    def get(self):
-        return self._cmd
-
-    async def wait_for_cmd(self):
-        await self._event.wait()
-        return self._cmd
 
 
 # Coordinator needs GPUs when using profiling to infer stage boundaries
@@ -48,7 +16,10 @@ class PromotionSignal:
 
 # Use manual stage annotations- more stable
 @ray.remote(num_gpus=0.1)
-def run_dp_rank(dp_rank, dp_degree, pp_degree, world_size, training_func: Callable, *args, num_standby=0, **kwargs):
+def run_dp_rank(
+    dp_rank, dp_degree, pp_degree, world_size, training_func: Callable, *args,
+    num_standby=0, coordinator=None, **kwargs,
+):
     logger = create_logger("coordinator", LOG_LEVEL)
     logger.debug(f"Running DP rank {dp_rank+1} of {dp_degree}")
 
@@ -58,12 +29,21 @@ def run_dp_rank(dp_rank, dp_degree, pp_degree, world_size, training_func: Callab
     os.environ["PIPER_WORLD_SIZE"] = str(world_size)
     os.environ["PIPER_NUM_STANDBY"] = str(num_standby)
     os.environ["TORCH_LOGS"] = "+graph_breaks"
+    # Via the module: Ray ships this function by value, so a directly
+    # referenced `piper_metadata` would be a pickled copy, not the singleton.
+    piper_state.piper_metadata.coordinator = coordinator
     return training_func(*args, **kwargs)
 
 
 @ray.remote
 class PiperProgramCoordinator:
-    """Central Actor that Coordinates all the DP replicas of a single pipeline"""
+    """Central actor that coordinates all the DP replicas of a single
+    pipeline: spawns and supervises the dp_rank driver tasks, and serves as
+    the promotion command channel and per-dp_rank actor registry.
+
+    cmd: None until set; then {"op": "promote", "failed": int, "source": int,
+    "new_ranks": [int, int]} or {"op": "shutdown"}.
+    """
 
     def __init__(
         self,
@@ -88,7 +68,33 @@ class PiperProgramCoordinator:
         # pp_rank). In that mode DP drivers are spread across the pp bundles.
         self.pp_outer = pp_outer
 
-    def run_program(self, training_func: Callable, pg, *args, **kwargs):
+        # Promotion command channel + per-dp_rank actor registry.
+        self._cmd = None
+        self._cmd_event = asyncio.Event()
+        self._actors = {}
+
+    # ---- driver-facing API ----
+
+    def register_actors(self, dp_rank, handles):
+        self._actors[dp_rank] = handles
+
+    def get_actors(self, dp_rank):
+        return self._actors.get(dp_rank)
+
+    def get_cmd(self):
+        return self._cmd
+
+    async def wait_for_cmd(self):
+        await self._cmd_event.wait()
+        return self._cmd
+
+    def _set_cmd(self, cmd):
+        self._cmd = cmd
+        self._cmd_event.set()
+
+    # ---- supervision ----
+
+    async def run_program(self, training_func: Callable, pg, *args, **kwargs):
         from .compile import _RANK0_ADDR_ACTOR, _COMPILED_DATA_ACTOR
         logger = create_logger("coordinator", LOG_LEVEL)
         try:
@@ -108,16 +114,7 @@ class PiperProgramCoordinator:
             logger.exception("Failed to kill stale Ray actor named %s", _COMPILED_DATA_ACTOR)
             raise
 
-        sig = None
-        if self.num_standby > 0:
-            try:
-                ray.kill(ray.get_actor(_PROMOTION_SIGNAL_ACTOR))
-            except ValueError:
-                pass
-            sig = PromotionSignal.options(
-                name=_PROMOTION_SIGNAL_ACTOR, num_cpus=0
-            ).remote()
-            ray.get(sig.get.remote())  # ensure the name is resolvable before drivers start
+        self_handle = ray.get_runtime_context().current_actor
 
         n_ranks = self.dp_degree + self.num_standby
         refs = [
@@ -136,17 +133,19 @@ class PiperProgramCoordinator:
                 training_func,
                 *args,
                 num_standby=self.num_standby,
+                coordinator=self_handle,
                 **kwargs,
             )
             for dp_rank in range(n_ranks)
         ]
-        ref_to_rank = {ref: dp_rank for dp_rank, ref in enumerate(refs)}
-        trainer_pending = set(refs[: self.dp_degree])
-        standby_refs = set(refs[self.dp_degree:])
+        tasks = [asyncio.ensure_future(ref) for ref in refs]
+        task_to_rank = {task: dp_rank for dp_rank, task in enumerate(tasks)}
+        trainer_pending = set(tasks[: self.dp_degree])
+        standby_tasks = set(tasks[self.dp_degree:])
 
         # React to whichever dp_rank task finishes or fails first. Standby
         # tasks are excluded from failure accounting.
-        pending = list(refs)
+        pending = set(tasks)
         results = []
         failures = 0
         promoted = False
@@ -154,7 +153,7 @@ class PiperProgramCoordinator:
         alive_standby = list(range(self.dp_degree, n_ranks))
         while pending:
             if (
-                sig is not None
+                self.num_standby > 0
                 and not promoted
                 and not shutdown_sent
                 and not trainer_pending
@@ -162,14 +161,19 @@ class PiperProgramCoordinator:
                 # All trainer tasks resolved without promotion: release the
                 # parked standby so the job can terminate.
                 logger.info("all trainer tasks resolved; sending shutdown to standby")
-                ray.get(sig.set.remote({"op": "shutdown"}))
+                self._set_cmd({"op": "shutdown"})
                 shutdown_sent = True
-            done, pending = ray.wait(pending, num_returns=1)
-            rank = ref_to_rank[done[0]]
-            trainer_pending.discard(done[0])
+            done, pending = await asyncio.wait(
+                pending, return_when=asyncio.FIRST_COMPLETED
+            )
+            # One task per iteration, as with ray.wait(num_returns=1).
+            task = done.pop()
+            pending |= done
+            rank = task_to_rank[task]
+            trainer_pending.discard(task)
             try:
-                res = ray.get(done[0])
-                if done[0] in standby_refs:
+                res = task.result()
+                if task in standby_tasks:
                     # Case 1 (no failure): standby was shut down, returns None,
                     # no metrics to record — drop is correct.
                     # TODO(phase-2), case 2 (promoted): the standby trained as a
@@ -178,7 +182,7 @@ class PiperProgramCoordinator:
                 else:
                     results.append(res)
             except Exception:
-                if done[0] in standby_refs:
+                if task in standby_tasks:
                     logger.exception(
                         f"standby dp_rank {rank} task failed; failover disabled"
                     )
@@ -190,20 +194,20 @@ class PiperProgramCoordinator:
                     f"a dp_rank task failed ({failures}/{self.dp_degree})"
                 )
                 if (
-                    sig is not None
+                    self.num_standby > 0
                     and alive_standby
                     and not promoted
                     and failures < self.dp_degree # at least one trainer survives
                 ):
                     promoted = True
-                    self._promote(sig, logger, failed_rank=rank,
-                                  standby_rank=alive_standby[0])
+                    await self._promote(logger, failed_rank=rank,
+                                        standby_rank=alive_standby[0])
                     continue
                 # No standby available for this failure: fail fast.
                 raise
         return results
 
-    def _promote(self, sig, logger, failed_rank: int, standby_rank: int):
+    async def _promote(self, logger, failed_rank: int, standby_rank: int):
         """Promote a standby to replace a failed trainer rank.
 
         failed_rank: dp_rank whose task failed.
@@ -222,13 +226,19 @@ class PiperProgramCoordinator:
             "new_ranks": new_ranks,
         }
         logger.info(f"promoting standby {standby_rank} for failed rank {failed_rank}: {cmd}")
-        # Order matters: the signal must be readable BEFORE any abort lands,
+        # Order matters: the command must be readable BEFORE any abort lands,
         # so fenced drivers can distinguish the abort from a genuine failure.
-        ray.get(sig.set.remote(cmd))
+        self._set_cmd(cmd)
         for rank in survivors:
-            handles = ray.get(sig.get_actors.remote(rank))
+            handles = self._actors.get(rank)
+            if not handles:
+                logger.warning(
+                    f"survivor dp_rank {rank} has no registered actors; "
+                    "cannot fence it"
+                )
+                continue
             for handle in handles:
-                ray.get(handle.abort_comms.remote(), timeout=60)
+                await asyncio.wait_for(handle.abort_comms.remote(), timeout=60)
 
 
 def create_piper_placement_group(

--- a/src/coordinator.py
+++ b/src/coordinator.py
@@ -8,6 +8,9 @@ from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from .state import create_logger, LOG_LEVEL
 from .schedule import load_schedule_info
 
+# No standby worker exists yet: fail fast on the first dp_rank failure.
+STANDBY_ENABLED = os.environ.get("PIPER_STANDBY_ENABLED", "0") == "1"
+
 
 # Coordinator needs GPUs when using profiling to infer stage boundaries
 # @ray.remote(num_gpus=0.1)
@@ -65,27 +68,46 @@ class PiperProgramCoordinator:
             logger.exception("Failed to kill stale Ray actor named %s", _COMPILED_DATA_ACTOR)
             raise
 
-        return ray.get(
-            [
-                run_dp_rank.options(
-                    scheduling_strategy=PlacementGroupSchedulingStrategy(
-                        placement_group=pg,
-                        placement_group_bundle_index=(
-                            dp_rank % self.pp_degree if self.pp_outer else dp_rank
-                        ),
-                    )
-                ).remote(
-                    dp_rank,
-                    self.dp_degree,
-                    self.pp_degree,
-                    self.world_size,
-                    training_func,
-                    *args,
-                    **kwargs,
+        refs = [
+            run_dp_rank.options(
+                scheduling_strategy=PlacementGroupSchedulingStrategy(
+                    placement_group=pg,
+                    placement_group_bundle_index=(
+                        dp_rank % self.pp_degree if self.pp_outer else dp_rank
+                    ),
                 )
-                for dp_rank in range(self.dp_degree)
-            ]
-        )
+            ).remote(
+                dp_rank,
+                self.dp_degree,
+                self.pp_degree,
+                self.world_size,
+                training_func,
+                *args,
+                **kwargs,
+            )
+            for dp_rank in range(self.dp_degree)
+        ]
+
+        # React to whichever dp_rank task finishes or fails first.
+        pending = list(refs)
+        results = []
+        failures = 0
+        while pending:
+            done, pending = ray.wait(pending, num_returns=1)
+            try:
+                results.append(ray.get(done[0]))
+            except Exception:
+                failures += 1
+                logger.exception(
+                    f"a dp_rank task failed ({failures}/{self.dp_degree})"
+                )
+                if not STANDBY_ENABLED:
+                    # M1: fail fast on first failure (see STANDBY_ENABLED above).
+                    raise
+                if failures == self.dp_degree:
+                    # Everyone is down — nothing left to wait for.
+                    raise
+        return results
 
 
 def create_piper_placement_group(schedule_directives_file: str, pp_outer: bool = False):

--- a/src/executors.py
+++ b/src/executors.py
@@ -491,9 +491,7 @@ class DagExecutor:
     # 0-based iteration counter, set by PiperActor.run_dag each call.
     # Debug-only: consumed by _maybe_inject_fault for E2E fault injection.
     _iter_count: int = 0
-    # Commit marker: _upd_begun = weights may be mutating for this iteration;
-    # _last_committed = optimizer update fully applied (recovery redoes +1).
-    _upd_begun: int = -1
+    # Commit marker: optimizer update fully applied (recovery redoes +1).
     _last_committed: int = -1
     # Set (before the comm abort) by PiperActor.abort_comms: an aborted
     # collective releases kernels with garbage, so a fenced step must not commit.
@@ -1017,7 +1015,6 @@ class DagExecutor:
 
     def _update(self, stream: torch.cuda.Stream, loss_buffer: list):
         self.params.drain_pending_frees()
-        self._upd_begun = self._iter_count
         if self.params.has_zero_shard_optimizers():
             if self._fenced:
                 raise RuntimeError(

--- a/src/executors.py
+++ b/src/executors.py
@@ -491,6 +491,15 @@ class DagExecutor:
     # 0-based iteration counter, set by PiperActor.run_dag each call.
     # Debug-only: consumed by _maybe_inject_fault for E2E fault injection.
     _iter_count: int = 0
+    # Commit marker: _upd_begun = weights may be mutating for this iteration;
+    # _last_committed = optimizer update fully applied (recovery redoes +1).
+    _upd_begun: int = -1
+    _last_committed: int = -1
+    # Set (before the comm abort) by PiperActor.abort_comms: an aborted
+    # collective releases kernels with garbage, so a fenced step must not commit.
+    _fenced: bool = False
+    # Standby mode only; off by default to keep the baseline hot path unchanged.
+    _cpu_sync_allreduce: bool = False
 
     @staticmethod
     def _node_meta(node: Any) -> dict:
@@ -580,6 +589,10 @@ class DagExecutor:
         """Run one iteration of the loaded TrainingDAG."""
         assert dag is not None, "load_training_dag() must be called before run_dag()"
         assert sorted_dag_nodes is not None, "load_training_dag() must initialize sorted node order"
+        if self._fenced:
+            raise RuntimeError(
+                "fenced by coordinator: communicators aborted, iteration refused"
+            )
 
         self.params.drain_pending_frees()
         debug_enabled = self.logger.isEnabledFor(logging.DEBUG)
@@ -1004,15 +1017,32 @@ class DagExecutor:
 
     def _update(self, stream: torch.cuda.Stream, loss_buffer: list):
         self.params.drain_pending_frees()
+        self._upd_begun = self._iter_count
         if self.params.has_zero_shard_optimizers():
+            if self._fenced:
+                raise RuntimeError(
+                    "fenced during collective; ZeRO optimizer step refused"
+                )
             self.params.step_zero_shard_optimizers(stream, self.events.reduce_scatter)
             losses = loss_buffer
             loss_buffer.clear()
             torch.cuda.synchronize()
+            self._last_committed = self._iter_count
             return losses
 
-        for ar_evt in self.events.all_reduce.values():
-            stream.wait_event(ar_evt)
+        if self._cpu_sync_allreduce:
+            # An aborted collective fires its events with garbage gradients;
+            # the outcome must be known (and unfenced) before stepping.
+            for ar_evt in self.events.all_reduce.values():
+                ar_evt.synchronize()
+            if self._fenced:
+                raise RuntimeError(
+                    "fenced during gradient all-reduce; optimizer step refused "
+                    f"(last_committed={self._last_committed})"
+                )
+        else:
+            for ar_evt in self.events.all_reduce.values():
+                stream.wait_event(ar_evt)
 
         for ubid, bucket in self.stages.buckets.items():
             if bucket.optimizer is None:
@@ -1028,6 +1058,8 @@ class DagExecutor:
         loss_buffer.clear()
 
         torch.cuda.synchronize()
+        # Only after synchronize returns are the weight updates provably applied.
+        self._last_committed = self._iter_count
 
         return {
             "losses": losses,

--- a/src/executors.py
+++ b/src/executors.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+import os
+import time
 from dataclasses import dataclass
 from typing import Any
 
@@ -12,6 +14,38 @@ from torch.nn import Parameter
 from .backward import construct_reverse_graph, get_param_groups, _get_grad_fn_or_grad_acc
 from .runtime import BufferStore, EventStore, ParamStorage, RuntimeState, StageStore
 from .tasks import TaskType
+
+
+def _maybe_inject_fault(pass_name: str, iter_count: int, dp_rank: int) -> None:
+    """Inject a debug fault when PIPER_FAULT matches the given execution point.
+
+    pass_name: name of the executing pass (e.g. "bwd").
+    iter_count: 0-based run_dag iteration counter (warmup iterations count).
+    dp_rank: this actor's DP rank.
+
+    PIPER_FAULT formats (never set in production runs):
+      "bwd:<iter>:<dp_rank>"            -> raise RuntimeError (loud mode)
+      "bwd:<iter>:<dp_rank>:sleep:<s>"  -> sleep s seconds    (stuck mode)
+    """
+    spec = os.environ.get("PIPER_FAULT")
+    if not spec:
+        return
+    parts = spec.split(":")
+    if parts[:3] != [pass_name, str(iter_count), str(dp_rank)]:
+        return
+    # One BWD node per annotated segment — latch to fire once per iteration.
+    key = (spec, iter_count)
+    if key in _FIRED_FAULTS:
+        return
+    _FIRED_FAULTS.add(key)
+    print(f"PIPER_FAULT firing: {spec}", flush=True)
+    if len(parts) >= 5 and parts[3] == "sleep":
+        time.sleep(float(parts[4]))
+        return
+    raise RuntimeError(f"injected fault ({spec})")
+
+
+_FIRED_FAULTS: set = set()
 
 
 @dataclass
@@ -454,6 +488,9 @@ class DagExecutor:
     communication: CommunicationExecutor
     compute: ComputeExecutor
     logger: Any
+    # 0-based iteration counter, set by PiperActor.run_dag each call.
+    # Debug-only: consumed by _maybe_inject_fault for E2E fault injection.
+    _iter_count: int = 0
 
     @staticmethod
     def _node_meta(node: Any) -> dict:
@@ -737,6 +774,7 @@ class DagExecutor:
                         self.params.defer_free_full_params(ubid, evt)
 
                 case TaskType.BWD:
+                    _maybe_inject_fault("bwd", self._iter_count, self.runtime.dp_rank)
                     recv_pred = next(
                         (p for p in node.data_preds if p.task_type == TaskType.RECV), None
                     )

--- a/src/piper.py
+++ b/src/piper.py
@@ -217,9 +217,15 @@ def piper(gm, example_inputs, **kwargs):
     return callback
 
 
-class PiperFencedError(Exception):
-    """Raised when this dp_rank's step was aborted by the coordinator during
-    standby promotion (not a real failure; the caller should stop cleanly)."""
+class PiperResume(Exception):
+    """Raised after promotion recovery completes.
+
+    next_iter: first iteration to (re-)execute.
+    """
+
+    def __init__(self, next_iter: int):
+        super().__init__(f"resume at iteration {next_iter}")
+        self.next_iter = next_iter
 
 
 def _promotion_cmd():
@@ -242,6 +248,8 @@ def piper_exec_dag(loss_fn, log_stats: bool = False, step_timeout: float | None 
     log_stats: log step time and throughput after the step.
     step_timeout: optional seconds to wait for the step before logging that it
         is overdue; None disables the overdue check.
+
+    Raises PiperResume after a standby promotion recovers this rank's step.
     """
     actors = piper_metadata.actors
     run_refs = [
@@ -249,52 +257,68 @@ def piper_exec_dag(loss_fn, log_stats: bool = False, step_timeout: float | None 
         for actor in actors.values()
     ]
     t0 = time.perf_counter()
-    if step_timeout is None:
-        results = ray.get(run_refs)
-    else:
-        # Keep waiting on the SAME refs (resubmitting would queue a second
-        # step behind a possibly-stuck one); genuine actor errors propagate.
-        while True:
-            try:
-                results = ray.get(run_refs, timeout=step_timeout)
-                break
-            except ray.exceptions.GetTimeoutError:
-                # TODO: stuck ranks cannot be handled here — this timeout
-                # fires identically on the stuck rank and on peers blocked at
-                # its rendezvous, so no local information can name the culprit.
-                logger.warning(
-                    f"step exceeded step_timeout={step_timeout:.1f}s; "
-                    "still waiting on in-flight step (peer may be down)"
+    while True:
+        try:
+            results = ray.get(run_refs, timeout=step_timeout)
+            break
+        except ray.exceptions.GetTimeoutError:
+            # TODO: stuck ranks cannot be handled here — this timeout
+            # fires identically on the stuck rank and on peers blocked at
+            # its rendezvous, so no local information can name the culprit.
+            logger.warning(
+                f"step exceeded step_timeout={step_timeout:.1f}s; "
+                "still waiting on in-flight step (peer may be down)"
+            )
+        except (ray.exceptions.RayTaskError, ray.exceptions.RayActorError) as e:
+            cmd = _promotion_cmd()
+            my_rank = int(os.environ.get("PIPER_DP_RANK", "-1"))
+            if (
+                cmd is not None
+                and cmd.get("op") == "promote"
+                and my_rank != cmd.get("failed")
+            ):
+                # Fenced by the coordinator: the abort of our comms ended
+                # this step; not a real failure of this rank.
+                logger.info(
+                    f"fenced by coordinator during promotion "
+                    f"(step error: {type(e).__name__}: {str(e.cause)[:200] if hasattr(e, 'cause') else str(e)[:200]})"
                 )
-            except (ray.exceptions.RayTaskError, ray.exceptions.RayActorError) as e:
-                cmd = _promotion_cmd()
-                my_rank = int(os.environ.get("PIPER_DP_RANK", "-1"))
-                if (
-                    cmd is not None
-                    and cmd.get("op") == "promote"
-                    and my_rank != cmd.get("failed")
-                ):
-                    # Fenced by the coordinator: the abort of our comms ended
-                    # this step; not a real failure of this rank.
+                survivor_actor = actors[0]
+                ray.get(
+                    survivor_actor.join_standby_group.remote(cmd["new_ranks"]),
+                    timeout=180,
+                )
+                lc = ray.get(survivor_actor.get_last_committed.remote(), timeout=60)
+                logger.info(
+                    f"survivor: joined standby group {cmd['new_ranks']}; "
+                    f"last_committed={lc}"
+                )
+                if my_rank == cmd.get("source"):
+                    standby_rank = next(
+                        r for r in cmd["new_ranks"] if r != cmd["source"]
+                    )
+                    from .coordinator import _PROMOTION_SIGNAL_ACTOR
+
+                    sig = ray.get_actor(_PROMOTION_SIGNAL_ACTOR)
+                    standby_actor = ray.get(
+                        sig.get_actors.remote(standby_rank)
+                    )[0]
+                    state_ref = ray.get(
+                        survivor_actor.make_state_ref.remote(), timeout=120
+                    )
+                    # Resume barrier: the survivor's live tensors must not
+                    # be stepped until the transfer has landed.
+                    ray.get(
+                        standby_actor.load_state.remote([state_ref]),
+                        timeout=300,
+                    )
+                    del state_ref
                     logger.info(
-                        f"fenced by coordinator during promotion "
-                        f"(step error: {type(e).__name__}: {str(e.cause)[:200] if hasattr(e, 'cause') else str(e)[:200]})"
+                        f"survivor: transferred state to standby "
+                        f"{standby_rank}; resuming at iteration {lc + 1}"
                     )
-                    survivor_actor = actors[0]
-                    res = ray.get(
-                        survivor_actor.join_standby_group.remote(cmd["new_ranks"]),
-                        timeout=180,
-                    )
-                    lc = ray.get(survivor_actor.get_last_committed.remote(), timeout=60)
-                    logger.info(
-                        f"survivor: joined standby group {cmd['new_ranks']} "
-                        f"(sanity allreduce={res}); last_committed={lc}; "
-                        f"recovery would redo iteration {lc + 1}"
-                    )
-                    raise PiperFencedError(
-                        f"fenced at last_committed={lc}"
-                    ) from e
-                raise
+                raise PiperResume(lc + 1) from e
+            raise
     step_time = time.perf_counter() - t0
 
     if log_stats:

--- a/src/piper.py
+++ b/src/piper.py
@@ -1,3 +1,4 @@
+import os
 import time
 from contextlib import contextmanager
 from typing import Iterator
@@ -216,6 +217,24 @@ def piper(gm, example_inputs, **kwargs):
     return callback
 
 
+class PiperFencedError(Exception):
+    """Raised when this dp_rank's step was aborted by the coordinator during
+    standby promotion (not a real failure; the caller should stop cleanly)."""
+
+
+def _promotion_cmd():
+    """Return the active promotion command, or None when no standby machinery
+    exists (M1 behavior) or no promotion is in progress."""
+    from .coordinator import _PROMOTION_SIGNAL_ACTOR
+
+    try:
+        sig = ray.get_actor(_PROMOTION_SIGNAL_ACTOR)
+    except ValueError:
+        # No signal actor: num_standby == 0, plain M1 behavior.
+        return None
+    return ray.get(sig.get.remote(), timeout=10)
+
+
 def piper_exec_dag(loss_fn, log_stats: bool = False, step_timeout: float | None = None) -> list:
     """Execute one training step using the loaded per-rank TrainingDAG.
 
@@ -234,16 +253,48 @@ def piper_exec_dag(loss_fn, log_stats: bool = False, step_timeout: float | None 
         results = ray.get(run_refs)
     else:
         # Keep waiting on the SAME refs (resubmitting would queue a second
-        # step behind a possibly-stuck one); actor errors propagate.
+        # step behind a possibly-stuck one); genuine actor errors propagate.
         while True:
             try:
                 results = ray.get(run_refs, timeout=step_timeout)
                 break
             except ray.exceptions.GetTimeoutError:
+                # TODO: stuck ranks cannot be handled here — this timeout
+                # fires identically on the stuck rank and on peers blocked at
+                # its rendezvous, so no local information can name the culprit.
                 logger.warning(
                     f"step exceeded step_timeout={step_timeout:.1f}s; "
                     "still waiting on in-flight step (peer may be down)"
                 )
+            except (ray.exceptions.RayTaskError, ray.exceptions.RayActorError) as e:
+                cmd = _promotion_cmd()
+                my_rank = int(os.environ.get("PIPER_DP_RANK", "-1"))
+                if (
+                    cmd is not None
+                    and cmd.get("op") == "promote"
+                    and my_rank != cmd.get("failed")
+                ):
+                    # Fenced by the coordinator: the abort of our comms ended
+                    # this step; not a real failure of this rank.
+                    logger.info(
+                        f"fenced by coordinator during promotion "
+                        f"(step error: {type(e).__name__}: {str(e.cause)[:200] if hasattr(e, 'cause') else str(e)[:200]})"
+                    )
+                    survivor_actor = actors[0]
+                    res = ray.get(
+                        survivor_actor.join_standby_group.remote(cmd["new_ranks"]),
+                        timeout=180,
+                    )
+                    lc = ray.get(survivor_actor.get_last_committed.remote(), timeout=60)
+                    logger.info(
+                        f"survivor: joined standby group {cmd['new_ranks']} "
+                        f"(sanity allreduce={res}); last_committed={lc}; "
+                        f"recovery would redo iteration {lc + 1}"
+                    )
+                    raise PiperFencedError(
+                        f"fenced at last_committed={lc}"
+                    ) from e
+                raise
     step_time = time.perf_counter() - t0
 
     if log_stats:

--- a/src/piper.py
+++ b/src/piper.py
@@ -231,14 +231,9 @@ class PiperResume(Exception):
 def _promotion_cmd():
     """Return the active promotion command, or None when no standby machinery
     exists (M1 behavior) or no promotion is in progress."""
-    from .coordinator import _PROMOTION_SIGNAL_ACTOR
-
-    try:
-        sig = ray.get_actor(_PROMOTION_SIGNAL_ACTOR)
-    except ValueError:
-        # No signal actor: num_standby == 0, plain M1 behavior.
+    if int(os.environ.get("PIPER_NUM_STANDBY", "0")) <= 0:
         return None
-    return ray.get(sig.get.remote(), timeout=10)
+    return ray.get(piper_metadata.coordinator.get_cmd.remote(), timeout=10)
 
 
 def piper_exec_dag(loss_fn, log_stats: bool = False, step_timeout: float | None = None) -> list:
@@ -297,11 +292,8 @@ def piper_exec_dag(loss_fn, log_stats: bool = False, step_timeout: float | None 
                     standby_rank = next(
                         r for r in cmd["new_ranks"] if r != cmd["source"]
                     )
-                    from .coordinator import _PROMOTION_SIGNAL_ACTOR
-
-                    sig = ray.get_actor(_PROMOTION_SIGNAL_ACTOR)
                     standby_actor = ray.get(
-                        sig.get_actors.remote(standby_rank)
+                        piper_metadata.coordinator.get_actors.remote(standby_rank)
                     )[0]
                     state_ref = ray.get(
                         survivor_actor.make_state_ref.remote(), timeout=120

--- a/src/piper.py
+++ b/src/piper.py
@@ -230,7 +230,7 @@ class PiperResume(Exception):
 
 def _promotion_cmd():
     """Return the active promotion command, or None when no standby machinery
-    exists (M1 behavior) or no promotion is in progress."""
+    exists or no promotion is in progress."""
     if int(os.environ.get("PIPER_NUM_STANDBY", "0")) <= 0:
         return None
     return ray.get(piper_metadata.coordinator.get_cmd.remote(), timeout=10)

--- a/src/piper.py
+++ b/src/piper.py
@@ -216,15 +216,34 @@ def piper(gm, example_inputs, **kwargs):
     return callback
 
 
-def piper_exec_dag(loss_fn, log_stats: bool = False) -> list:
-    """Execute one training step using the loaded per-rank TrainingDAG."""
+def piper_exec_dag(loss_fn, log_stats: bool = False, step_timeout: float | None = None) -> list:
+    """Execute one training step using the loaded per-rank TrainingDAG.
+
+    loss_fn: loss function forwarded to each actor's run_dag.
+    log_stats: log step time and throughput after the step.
+    step_timeout: optional seconds to wait for the step before logging that it
+        is overdue; None disables the overdue check.
+    """
     actors = piper_metadata.actors
     run_refs = [
         actor.run_dag.remote(loss_fn=loss_fn)
         for actor in actors.values()
     ]
     t0 = time.perf_counter()
-    results = ray.get(run_refs)
+    if step_timeout is None:
+        results = ray.get(run_refs)
+    else:
+        # Keep waiting on the SAME refs (resubmitting would queue a second
+        # step behind a possibly-stuck one); actor errors propagate.
+        while True:
+            try:
+                results = ray.get(run_refs, timeout=step_timeout)
+                break
+            except ray.exceptions.GetTimeoutError:
+                logger.warning(
+                    f"step exceeded step_timeout={step_timeout:.1f}s; "
+                    "still waiting on in-flight step (peer may be down)"
+                )
     step_time = time.perf_counter() - t0
 
     if log_stats:

--- a/src/state.py
+++ b/src/state.py
@@ -40,6 +40,7 @@ Piper thread local storage for tracking Piper actors, stages, and microbatches
 
 class PiperMetadata:
     actors = dict()
+    coordinator = None  # Handle of the PiperProgramCoordinator supervising this dp_rank driver
     visualize_dag: bool = False  # Whether to render per-rank DAG PNGs after compilation
     artifact_dir: str = "out"  # Directory for debug artifacts emitted during runs
     training_dag = None  # DAG of annotated model segments and transform-inserted nodes


### PR DESCRIPTION
- `PiperProgramCoordinator` becomes an async centralized controller: spawns and supervises dp_rank tasks, and serves promotion/shutdown commands to them.
- `--num-standby N` reserves N extra DP ranks that initialize upfront and park; on a trainer failure one is promoted, the survivor fences its optimizer step, aborts its NCCL groups, and rejoins with the standby.
- Survivor's weights/optimizer state are transferred to the standby via NIXL (RDT); both resume in lockstep at `last_committed + 1`.

Limits: 
- The promoted standby's iterations are not in `results.csv`;
- Hangs are detected but not recovered. 

User facing docs in `docs/`.

Test (3 GPUs; fault on rank 1 at iteration 4 → standby 2 promoted, training resumes at iteration 4, exit 0; ~4 s fault→resume):
```shell
CUDA_VISIBLE_DEVICES=0,1,2 PIPER_FAULT=bwd:4:1 python examples/test_harness.py \
  --test-file examples/test_qwen.py --base-schedule examples/base-schedules/dp2.json \
  --schedule 1f1b --ranks 1 --mbs 1 --num-standby 1
```